### PR TITLE
fix save user without dumping

### DIFF
--- a/scenarios/user/user_model.py
+++ b/scenarios/user/user_model.py
@@ -31,7 +31,7 @@ class User(BaseUser):
     def __init__(self, id, message, db_data, settings, descriptions, parametrizer_cls, load_error=False):
         self.settings = settings
         try:
-            user_values = json.loads(db_data) if db_data else None
+            user_values = db_data if db_data else None
         except ValueError:
             user_values = None
             smart_kit_metrics.counter_load_error(settings.app_name)

--- a/smart_kit/start_points/base_main_loop.py
+++ b/smart_kit/start_points/base_main_loop.py
@@ -125,13 +125,13 @@ class BaseMainLoop:
 
             no_collisions = True
             try:
-                str_data = user.raw_str
+                user_data = user.raw
                 if user.initial_db_data and self.user_save_check_for_collisions:
                     no_collisions = self.db_adapter.replace_if_equals(db_uid,
                                                                       sample=user.initial_db_data,
-                                                                      data=str_data)
+                                                                      data=user_data)
                 else:
-                    self.db_adapter.save(db_uid, str_data)
+                    self.db_adapter.save(db_uid, user_data)
             except (DBAdapterException, ValueError):
                 log("Failed to set user data", params={log_const.KEY_NAME: log_const.FAILED_DB_INTERACTION,
                                                        log_const.REQUEST_VALUE: str(message.value)}, level="ERROR")


### PR DESCRIPTION
Fix of the serialization of unserializable object is done by this pull request.

The problem is that `user.raw_str` lead to serialization error. More specifically, trying of getting `user.raw_str` involve `json.dumps(user.raw)` that inside of user.raw tries to serialise the `fields` of `user` that may contain unseralizable objects, such as `user.gender_selector.get_text_by_key`. It is fixed by removing try to serialize such objects.

How to reproduce:
1. `python3 -m smart_kit create_app kafka_test_app`
2.  _app_config.py_
``` 
from smart_kit.start_points.main_loop_kafka import MainLoop
MAIN_LOOP = MainLoop
```
3. python3 manage.py run_app
4. Catch some message from Kafka
5. 
```
[ERROR] smart_kit.start_points.main_loop_kafka 2022-04-27 12:24:54,591 logger_utils: MainLoop iterate error. Kafka key main MESSAGE: b'{"messageId": 12345678, "sessionId": "b7abcdea-eac8-436a-a9ac-c7fff4d9e6eb", "messageName": "RUN_APP", "uuid": {"userId": "3677a803-ee9f-4fd6-85f7-2ce747800c46", "userChannel": "B2C"}, "payload": {"applicationId": "d7c7178e-99d8-4192-962f-34c3940a6fdf", "appversionId": "672af7be-23d8-4d9c-95a2-f3e72c722145", "projectName": "music", "intent": "run_app", "token": "***", "message": {"original_text": "\xd0\xb2\xd0\xba\xd0\xbb\xd1\x8e\xd1\x87\xd0\xb8 \xd0\xbc\xd1\x83\xd0\xb7\xd1\x8b\xd0\xba\xd1\x83", "normalized_text": "\xd0\xb2\xd0\xba\xd0\xbb\xd1\x8e\xd1\x87\xd0\xb8\xd1\x82\xd1\x8c \xd0\xbc\xd1\x83\xd0\xb7\xd1\x8b\xd0\xba\xd0\xb0 ."}, "device": {"surface": "HEAD_UNIT", "surfaceVersion": "1.54.20200710192606", "deviceId": "GZ200301320000035"}, "app_info": {"projectId": "2c96f0b4-4be9-4fb6-b80f-f7f83395042e", "applicationId": "d7c7178e-99d8-4192-962f-34c3940a6fdf"}, "meta": {}, "selected_item": {}, "contentProvider": {}}}'.
Traceback (most recent call last):
  File "/Users/shevchenkomakar/Documents/Documents/Code/Sber/framework_testing/smart_app_framework/smart_kit/start_points/main_loop_kafka.py", line 339, in iterate
    self.process_message(mq_message, consumer, kafka_key, stats)
  File "/Users/shevchenkomakar/Documents/Documents/Code/Sber/framework_testing/smart_app_framework/smart_kit/start_points/main_loop_kafka.py", line 272, in process_message
    user_save_no_collisions = self.save_user(db_uid, user, message)
  File "/Users/shevchenkomakar/Documents/Documents/Code/Sber/framework_testing/smart_app_framework/smart_kit/start_points/base_main_loop.py", line 128, in save_user
    str_data = user.raw_str
  File "/Users/shevchenkomakar/Documents/Documents/Code/Sber/framework_testing/smart_app_framework/core/model/base_user.py", line 64, in raw_str
    raw = json.dumps(self.raw)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object {o} of type {o.__class__.__name__} '
TypeError: Object <bound method ReplySelector.get_text_by_key of <scenarios.user.reply_selector.reply_selector.ReplySelector object at 0x7f96a1b72fa0>> of type method is not JSON serializable
```