### PR TITLE
DPNLPF-1648: ssml_test command

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest
       run: |
-        python -m unittest discover -s tests
+        python -m unittest discover -s tests -v
     - name: Test run_app on HttpMainLoop
       run: |
         python -m smart_kit create_app http_test_app

--- a/smart_kit/configs/__init__.py
+++ b/smart_kit/configs/__init__.py
@@ -47,6 +47,8 @@ def get_app_config(environment_variable=ENVIRONMENT_VARIABLE):
     from smart_kit.text_preprocessing.local_text_normalizer import LocalTextNormalizer
     from smart_kit.utils.cache import JSONCache
     from smart_kit.testing.suite import TestCase
+    from smart_kit.testing.ssml_test.suite import SsmlTestSuite
+    from smart_kit.testing.ssml_test.ssml_string_parser import ssml_string_parser
 
     set_default(app_config, "LOCAL_TESTING", CLInterface)
     set_default(app_config, "TEST_CASE", TestCase)
@@ -63,6 +65,12 @@ def get_app_config(environment_variable=ENVIRONMENT_VARIABLE):
     set_default(app_config, "SETTINGS", Settings)
     set_default(app_config, "RESOURCES", SmartAppResources)
     set_default(app_config, "FROM_MSG", SmartAppFromMessage)
+    set_default(app_config, "SSML_TEST_SUITE", SsmlTestSuite)
+    set_default(app_config, "SSML_TEST_ADDRESS", "http://1.2.3.4:1234/todo")  # TODO replace url according to API
+    set_default(app_config, "RESOURCE_TO_SSML_STRING_PARSER", {"scenarios": ssml_string_parser,
+                                                               "forms": ssml_string_parser,
+                                                               "external_actions": ssml_string_parser,
+                                                               "behaviors": ssml_string_parser})
 
     set_default(app_config, "NORMALIZATION_CACHE_TTL", 0)
     set_default(app_config, "NORMALIZATION_CACHE", JSONCache)

--- a/smart_kit/testing/ssml_test/ssml_string_parser.py
+++ b/smart_kit/testing/ssml_test/ssml_string_parser.py
@@ -1,0 +1,24 @@
+from typing import List, Tuple, Any
+
+from core.logging.logger_utils import log
+from smart_kit.utils.object_location import ObjectLocation
+
+
+def ssml_string_parser(obj: Any, location: ObjectLocation) -> List[Tuple[str, ObjectLocation]]:
+    ssml_strings = []
+    if isinstance(obj, dict):
+        # For pattern (dict contain ["command": "ANSWER_TO_USER"; nodes.pronounceTextType = "application/ssml"])
+        # get nodes.pronounceText
+        if obj.get("command") == "ANSWER_TO_USER" and \
+           obj.get("nodes", {}).get("pronounceTextType") == "application/ssml":  # TODO решить должна ли быть на это проверка в соответствии с аналитикой Оли
+            if "pronounceText" not in obj["nodes"]:
+                log("Missing nodes.pronounceText in action", level="WARNING")
+            else:
+                ssml_strings.append((obj["nodes"]["pronounceText"],
+                                     ObjectLocation(location.object_location + ["nodes", "pronounceText"])))
+        for field_key, field_val in obj.items():
+            ssml_strings.extend(ssml_string_parser(field_val, ObjectLocation(location.object_location + [field_key])))
+    elif isinstance(obj, (list, set, tuple)):
+        for i, val in enumerate(obj):
+            ssml_strings.extend(ssml_string_parser(val, ObjectLocation(location.object_location + [f"[{i}]"])))
+    return ssml_strings

--- a/smart_kit/testing/ssml_test/suite.py
+++ b/smart_kit/testing/ssml_test/suite.py
@@ -1,0 +1,69 @@
+
+from typing import Tuple, Dict, Callable, Any, List
+
+import requests
+
+from core.logging.logger_utils import log
+from smart_kit.resources import SmartAppResources
+from smart_kit.utils.object_location import ObjectLocation
+
+
+class SsmlTestSuite:
+    def __init__(self, ssml_test_url: str):
+        self.ssml_test_url = ssml_test_url
+
+    def test_single_string(self, string_to_test: str):
+        is_valid, message = self.check_ssml_string(string_to_test, self.ssml_test_url)
+        if is_valid:
+            print(f"[+] OK")
+        else:
+            print(f"[!] SSML markup of the string is invalid. Message: \"{message}\"")
+
+    def test_statics(self,
+                     resources: SmartAppResources,
+                     resource_to_ssml_string_parser: Dict[str, Callable[[Any, ObjectLocation],
+                                                                        List[Tuple[str, ObjectLocation]]]]):
+        ssml_strings = self.collect_ssml_strings(resources, resource_to_ssml_string_parser)
+        success_num = 0
+        total_num = len(ssml_strings)
+        for ssml_string, location in ssml_strings:
+            print(f"[+] Testing SSML string {ssml_string} from {location}")
+            print(f"[+] OK")
+            is_valid, message = self.check_ssml_string(ssml_string, self.ssml_test_url)
+            if is_valid:
+                success_num += 1
+            else:
+                print(f"[!] SSML markup of the string is invalid. Message: {message}")
+        print(f"[+] Total: {success_num}/{total_num}")
+
+    def collect_ssml_strings(
+            self,
+            resources: SmartAppResources,
+            resource_ssml_string_parsers: Dict[str, Callable[[Any, ObjectLocation], List[Tuple[str, ObjectLocation]]]]) \
+            -> List[Tuple[str, ObjectLocation]]:
+        """Returns list of tuples of parsed ssml-string and its location"""
+        ssml_strings = []
+        for resource_name, ssml_extractor in resource_ssml_string_parsers.items():
+            resource = resources.get(resource_name)
+            if resource:
+                extracted_strings = ssml_extractor(resource, ObjectLocation([resource_name]))
+                ssml_strings.extend(extracted_strings)
+            else:
+                log(f"{resource_name} do not exist in resources", level="WARNING")
+        return ssml_strings
+
+    def check_ssml_string(self, string_to_test: str, ssml_checker_url: str) -> Tuple[bool, str]:
+        """Returns whether ssml_string is valid and message describing invalidity"""
+        # TODO: insert ssml_string as parameter according to API
+        response = requests.get(f"{ssml_checker_url}/{string_to_test}")
+        if not response:
+            raise Exception(f"Error during connecting to {ssml_checker_url}\n"
+                            f"Status: {response.status_code}\n"
+                            f"Reason: {response.reason}")
+        response_json = response.json()
+        is_valid = response_json["is_valid"]
+        if is_valid:
+            return True, ""
+        else:
+            message = response_json["message"]
+            return False, message

--- a/smart_kit/testing/ssml_test/suite.py
+++ b/smart_kit/testing/ssml_test/suite.py
@@ -28,10 +28,10 @@ class SsmlTestSuite:
         total_num = len(ssml_strings)
         for ssml_string, location in ssml_strings:
             print(f"[+] Testing SSML string {ssml_string} from {location}")
-            print(f"[+] OK")
             is_valid, message = self.check_ssml_string(ssml_string, self.ssml_test_url)
             if is_valid:
                 success_num += 1
+                print(f"[+] OK")
             else:
                 print(f"[!] SSML markup of the string is invalid. Message: {message}")
         print(f"[+] Total: {success_num}/{total_num}")

--- a/smart_kit/utils/object_location.py
+++ b/smart_kit/utils/object_location.py
@@ -1,0 +1,9 @@
+from typing import List
+
+
+class ObjectLocation:
+    def __init__(self, object_location: List[str]):
+        self.object_location = object_location
+
+    def __str__(self):
+        return '.'.join(self.object_location)


### PR DESCRIPTION
Реализовать в WF запрос на валидацию SSML через ручку, которая на вход принимает текст-SSML, а на выходе отдаёт JSON вида
{
    "is_valid": true
}
или
{
    "is_valid": false,
    "message": <текстовое описание ошибки>
}

# Поддержка валидации SSML разметки
Реализована команда ssml_test, с помощью которой можно протестировать SSML-разметку отдельной строки или же всех статиков.

## Использование
`python manage.py ssml_test (--statics | --string STRING)` \
где
- `--statics` производит тест ssml-строк в статиках
- `--string STRING` производит тест введённой строки

Опционально можно сконфигурировать работу инструмента в *app_config.py* навыка, переопределив поля:
- `SSML_TEST_ADDRESS` - url API сервиса проверки SSML-разметки
- `RESOURCE_TO_SSML_STRING_PARSER` - словарь, где ключ - имени проверяемого ресурса, а значение - функция-парсер SSML-строк для ресурса (интерфейс: `Callable[[Any, ObjectLocation], List[Tuple[str, ObjectLocation]]]`)
- `SSML_TEST_SUITE` - класс-инструмент для проверки SSML-строк, отнаследованный от `SsmlTestSuite`