### PR TITLE
DPNLPF-1692 Reply to topic "kafka_replyTopic" if it exists in message headers

### DIFF
--- a/core/configs/global_constants.py
+++ b/core/configs/global_constants.py
@@ -3,6 +3,7 @@ import core.names.field as core_field
 CALLBACK_ID_HEADER = "app_callback_id"
 LINK_BEHAVIOR_FLAG = "link_previous_behavior"
 KAFKA = "kafka"
+KAFKA_REPLY_TOPIC = "kafka_replyTopic"
 
 ORIGINAL_INTENT = "original_intent"
 NEW_SESSION = "new_session"

--- a/core/message/from_message.py
+++ b/core/message/from_message.py
@@ -24,6 +24,9 @@ class Headers:
     def __getitem__(self, item):
         return self.raw[item].decode()
 
+    def __contains__(self, item):
+        return item in self.raw
+
     def get(self, key, default=None, encoding="utf-8"):
         res = self.raw.get(key)
         if res is None:

--- a/core/model/base_user.py
+++ b/core/model/base_user.py
@@ -20,6 +20,7 @@ class BaseUser(Model):
 
     counters: Counters
     variables: Variables
+    private_vars: Variables
     local_vars: Variables
 
     def __init__(self, id, message, values, descriptions, load_error=False):
@@ -46,6 +47,7 @@ class BaseUser(Model):
             Field("last_messages_ids", LimitedQueuedHashableObjects, LimitedQueuedHashableObjectsDescription(None)),
             Field("local_vars", Variables, None, False),
             Field("variables", Variables),
+            Field("private_vars", Variables),
         ]
 
     @property
@@ -54,7 +56,7 @@ class BaseUser(Model):
         raw = json.dumps(self.raw, default=lambda o: f"<non-serializable: {type(o).__qualname__}>")
         log("%(class_name)s.raw USER %(uid)s SAVE db_version = %(db_version)s. "
             "Saving User %(uid)s. Serialized utf8 json length is %(user_length)s symbols.", self,
-            {"db_version": str(self.variables.get(self.USER_DB_VERSION)),
+            {"db_version": str(self.private_vars.get(self.USER_DB_VERSION)),
              "uid": str(self.id), "user_length": len(raw),
              KEY_NAME: "user_save"})
         return raw
@@ -62,4 +64,5 @@ class BaseUser(Model):
     def expire(self):
         self.counters.expire()
         self.variables.expire()
+        self.private_vars.expire()
         self.local_vars.expire()

--- a/core/request/kafka_request.py
+++ b/core/request/kafka_request.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from core.request.base_request import BaseRequest
 
 
@@ -10,10 +12,7 @@ class KafkaRequest(BaseRequest):
         items = items or {}
         self.topic_key = items.get(self.TOPIC_KEY)
         self.kafka_key = items.get(self.KAFKA_KEY)
-
-    def update_empty_items(self, items):
-        self.topic_key = self.topic_key or items["topic_key"]
-        self.kafka_key = self.kafka_key or items["kafka_key"]
+        self.reply_to_topic_name: Optional[str] = None
 
     @property
     def group_key(self):
@@ -27,7 +26,20 @@ class KafkaRequest(BaseRequest):
         publishers = params["publishers"]
         publisher = publishers[self.kafka_key]
         source_mq_message = params["mq_message"]
-        publisher.send(data, source_mq_message.key(), self.topic_key, headers=self._get_new_headers(source_mq_message))
+        if self.reply_to_topic_name:
+            publisher.send_to_topic(
+                value=data,
+                key=source_mq_message.key(),
+                topic=self.reply_to_topic_name,
+                headers=self._get_new_headers(source_mq_message),
+            )
+        else:
+            publisher.send(
+                value=data,
+                key=source_mq_message.key(),
+                topic_key=self.topic_key,
+                headers=self._get_new_headers(source_mq_message),
+            )
 
     def __str__(self):
         return f"KafkaRequest: topic_key={self.topic_key} kafka_key={self.kafka_key}"

--- a/core/request/kafka_request.py
+++ b/core/request/kafka_request.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+from confluent_kafka.cimpl import Message as KafkaMessage
+from core.mq.kafka.kafka_publisher import KafkaPublisher
 from core.request.base_request import BaseRequest
 from core.logging.logger_utils import log
 import core.logging.logger_constants as log_const
@@ -27,16 +29,12 @@ class KafkaRequest(BaseRequest):
     def group_key(self):
         return "{}_{}".format(self.kafka_key, self.topic_key) if (self.topic_key and self.kafka_key) else None
 
-    def _get_new_headers(self, source_mq_message):
+    def _get_new_headers(self, source_mq_message: KafkaMessage):
         headers = source_mq_message.headers() or []
         return headers
 
-    def run(self, data, params=None):
-        publishers = params["publishers"]
-        publisher = publishers[self.kafka_key]
-        source_mq_message = params["mq_message"]
+    def send(self, data, publisher: KafkaPublisher, source_mq_message):
         headers = self._get_new_headers(source_mq_message)
-
         if self.topic_key is not None:
             publisher.send(data, source_mq_message.key(), self.topic_key, headers=headers)
         elif self.topic is not None:
@@ -46,7 +44,12 @@ class KafkaRequest(BaseRequest):
                 "data": str(data),
                 log_const.KEY_NAME: log_const.EXCEPTION_VALUE
             }
-            log("KafkaTopicRequest: got no topic and no topic_key", params=log_params, level="ERROR")
+            log("KafkaRequest: got no topic and no topic_key", params=log_params, level="ERROR")
+
+    def run(self, data, params=None):
+        publishers = params["publishers"]
+        publisher = publishers[self.kafka_key]
+        self.send(data=data, publisher=publisher, source_mq_message=params["mq_message"])
 
     def __str__(self):
         if self.topic_key is not None:

--- a/scenarios/user/user_model.py
+++ b/scenarios/user/user_model.py
@@ -44,8 +44,8 @@ class User(BaseUser):
         self.initial_db_data = db_data
 
     def _initialize(self):
-        db_version = self.variables.get(self.USER_DB_VERSION, default=0)
-        self.variables.set(self.USER_DB_VERSION, db_version + 1)
+        db_version = self.private_vars.get(self.USER_DB_VERSION, default=0)
+        self.private_vars.set(self.USER_DB_VERSION, db_version + 1)
         log("%(class_name)s.__init__ USER %(uid)s LOAD db_version = %(db_version)s.", self,
             params={"db_version": str(db_version),
                     "uid": str(self.id), log_const.KEY_NAME: "user_load"})

--- a/smart_kit/request/kafka_request.py
+++ b/smart_kit/request/kafka_request.py
@@ -1,11 +1,11 @@
 from typing import Dict
 
-from core.configs.global_constants import CALLBACK_ID_HEADER
+from core.configs.global_constants import CALLBACK_ID_HEADER, KAFKA_REPLY_TOPIC
 from core.request.kafka_request import KafkaRequest
 
 
 class SmartKitKafkaRequest(KafkaRequest):
-    KAFKA_REPLY_TOPIC = "kafka_replyTopic"
+    KAFKA_REPLY_TOPIC = KAFKA_REPLY_TOPIC
     KAFKA_EXTRA_HEADERS = "kafka_extraHeaders"
 
     def __init__(self, items, id=None):
@@ -18,13 +18,6 @@ class SmartKitKafkaRequest(KafkaRequest):
     @property
     def _callback_id_header_name(self):
         return CALLBACK_ID_HEADER
-
-    def update_empty_items(self, items: Dict[str, str]) -> None:
-        self.kafka_key = self.kafka_key or items["kafka_key"]
-        if (self.topic_key is None) and ("kafka_replyTopic" in items):
-            self.reply_to_topic_name = items["kafka_replyTopic"]
-        else:
-            self.topic_key = self.topic_key or items["topic_key"]
 
     def _get_new_headers(self, source_mq_message):
         headers_dict = dict(super(SmartKitKafkaRequest, self)._get_new_headers(source_mq_message))

--- a/smart_kit/request/kafka_request.py
+++ b/smart_kit/request/kafka_request.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from core.configs.global_constants import CALLBACK_ID_HEADER
 from core.request.kafka_request import KafkaRequest
 
@@ -16,6 +18,13 @@ class SmartKitKafkaRequest(KafkaRequest):
     @property
     def _callback_id_header_name(self):
         return CALLBACK_ID_HEADER
+
+    def update_empty_items(self, items: Dict[str, str]) -> None:
+        self.kafka_key = self.kafka_key or items["kafka_key"]
+        if (self.topic_key is None) and ("kafka_replyTopic" in items):
+            self.reply_to_topic_name = items["kafka_replyTopic"]
+        else:
+            self.topic_key = self.topic_key or items["topic_key"]
 
     def _get_new_headers(self, source_mq_message):
         headers_dict = dict(super(SmartKitKafkaRequest, self)._get_new_headers(source_mq_message))

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -119,7 +119,11 @@ class MainLoop(BaseMainLoop):
 
         for command in commands:
             request = SmartKitKafkaRequest(id=None, items=command.request_data)
-            request.update_empty_items({"topic_key": topic_key, "kafka_key": kafka_key})
+            request_params_to_update = {"kafka_key": kafka_key, "topic_key": topic_key}
+            if "kafka_replyTopic" in message.headers:
+                request_params_to_update["kafka_replyTopic"] = message.headers["kafka_replyTopic"]
+            request.update_empty_items(request_params_to_update)
+
             to_message = get_to_message(command.name)
             answer = to_message(command=command, message=message, request=request,
                                 masking_fields=self.masking_fields,

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -3,13 +3,15 @@ import json
 import time
 from collections import namedtuple
 from functools import lru_cache
+from typing import Optional
 
-from confluent_kafka.cimpl import KafkaException
+from confluent_kafka.cimpl import KafkaException, Message as KafkaMessage
 from lazy import lazy
 
 import scenarios.logging.logger_constants as log_const
-from core.basic_models.actions.push_action import PUSH_NOTIFY
+from core.configs.global_constants import KAFKA_REPLY_TOPIC
 from core.logging.logger_utils import log, UID_STR, MESSAGE_ID_STR
+from smart_kit.names.message_names import ANSWER_TO_USER
 
 from core.message.from_message import SmartAppFromMessage
 from core.model.heapq.heapq_storage import HeapqKV
@@ -119,10 +121,11 @@ class MainLoop(BaseMainLoop):
 
         for command in commands:
             request = SmartKitKafkaRequest(id=None, items=command.request_data)
-            request_params_to_update = {"kafka_key": kafka_key, "topic_key": topic_key}
-            if "kafka_replyTopic" in message.headers:
-                request_params_to_update["kafka_replyTopic"] = message.headers["kafka_replyTopic"]
-            request.update_empty_items(request_params_to_update)
+            request.update_empty_items({
+                "kafka_key": kafka_key,
+                "topic_key": topic_key,
+                "topic": user.private_vars.get(KAFKA_REPLY_TOPIC) if command.name == ANSWER_TO_USER else None
+            })
 
             to_message = get_to_message(command.name)
             answer = to_message(command=command, message=message, request=request,
@@ -213,7 +216,7 @@ class MainLoop(BaseMainLoop):
         topic_names_2_key = self._topic_names_2_key(kafka_key)
         return self.default_topic_key(kafka_key) or topic_names_2_key[mq_message.topic()]
 
-    def process_message(self, mq_message, consumer, kafka_key, stats):
+    def process_message(self, mq_message: KafkaMessage, consumer, kafka_key, stats):
         topic_key = self._get_topic_key(mq_message, kafka_key)
 
         save_tries = 0
@@ -262,6 +265,21 @@ class MainLoop(BaseMainLoop):
                     user = self.load_user(db_uid, message)
                 monitoring.sampling_load_time(self.app_name, load_timer.secs)
                 stats += "Loading time: {} msecs\n".format(load_timer.msecs)
+
+                if KAFKA_REPLY_TOPIC in message.headers:
+                    if user.private_vars.get(KAFKA_REPLY_TOPIC):
+                        log("MainLoop.iterate: kafka_replyTopic collision",
+                            params={log_const.KEY_NAME: "ignite_collision",
+                                    "db_uid": db_uid,
+                                    "message_key": mq_message.key(),
+                                    "message_partition": mq_message.partition(),
+                                    "kafka_key": kafka_key,
+                                    "uid": user.id,
+                                    "saved_topic": user.private_vars.get(KAFKA_REPLY_TOPIC),
+                                    "current_topic": message.headers[KAFKA_REPLY_TOPIC]},
+                            user=user, level="WARNING")
+                    user.private_vars.set(KAFKA_REPLY_TOPIC, message.headers[KAFKA_REPLY_TOPIC])
+
                 with StatsTimer() as script_timer:
                     commands = self.model.answer(message, user)
 
@@ -330,7 +348,7 @@ class MainLoop(BaseMainLoop):
 
     def iterate(self, kafka_key):
         consumer = self.consumers[kafka_key]
-        mq_message = None
+        mq_message: Optional[KafkaMessage] = None
         message_value = None
         try:
             mq_message = None

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -11,7 +11,7 @@ from lazy import lazy
 import scenarios.logging.logger_constants as log_const
 from core.configs.global_constants import KAFKA_REPLY_TOPIC
 from core.logging.logger_utils import log, UID_STR, MESSAGE_ID_STR
-from smart_kit.names.message_names import ANSWER_TO_USER
+from smart_kit.names.message_names import ANSWER_TO_USER, RUN_APP, MESSAGE_TO_SKILL, SERVER_ACTION, CLOSE_APP
 
 from core.message.from_message import SmartAppFromMessage
 from core.model.heapq.heapq_storage import HeapqKV
@@ -266,7 +266,8 @@ class MainLoop(BaseMainLoop):
                 monitoring.sampling_load_time(self.app_name, load_timer.secs)
                 stats += "Loading time: {} msecs\n".format(load_timer.msecs)
 
-                if KAFKA_REPLY_TOPIC in message.headers:
+                if KAFKA_REPLY_TOPIC in message.headers and \
+                        message.message_name in [RUN_APP, MESSAGE_TO_SKILL, SERVER_ACTION, CLOSE_APP]:
                     if user.private_vars.get(KAFKA_REPLY_TOPIC):
                         log("MainLoop.iterate: kafka_replyTopic collision",
                             params={log_const.KEY_NAME: "ignite_collision",

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -181,7 +181,7 @@ class MainLoop(BaseMainLoop):
                                     "message_key": mq_message.key(),
                                     "kafka_key": kafka_key,
                                     "uid": user.id,
-                                    "db_version": str(user.variables.get(user.USER_DB_VERSION))},
+                                    "db_version": str(user.private_vars.get(user.USER_DB_VERSION))},
                             level="WARNING")
 
                         continue
@@ -196,7 +196,7 @@ class MainLoop(BaseMainLoop):
                                 "message_partition": mq_message.partition(),
                                 "kafka_key": kafka_key,
                                 "uid": user.id,
-                                "db_version": str(user.variables.get(user.USER_DB_VERSION))},
+                                "db_version": str(user.private_vars.get(user.USER_DB_VERSION))},
                         level="WARNING")
 
                     monitoring.counter_save_collision_tries_left(self.app_name)
@@ -286,7 +286,7 @@ class MainLoop(BaseMainLoop):
                                 "message_partition": mq_message.partition(),
                                 "kafka_key": kafka_key,
                                 "uid": user.id,
-                                "db_version": str(user.variables.get(user.USER_DB_VERSION))},
+                                "db_version": str(user.private_vars.get(user.USER_DB_VERSION))},
                         level="WARNING")
                     continue
 
@@ -322,7 +322,7 @@ class MainLoop(BaseMainLoop):
                         "message_partition": mq_message.partition(),
                         "kafka_key": kafka_key,
                         "uid": user.id,
-                        "db_version": str(user.variables.get(user.USER_DB_VERSION))},
+                        "db_version": str(user.private_vars.get(user.USER_DB_VERSION))},
                 level="WARNING")
             self.postprocessor.postprocess(user, message)
             monitoring.counter_save_collision_tries_left(self.app_name)

--- a/tests/smart_kit_tests/request/test_kafka_request.py
+++ b/tests/smart_kit_tests/request/test_kafka_request.py
@@ -11,6 +11,7 @@ class RequestTest1(unittest.TestCase):
                            "app_callback_id": 22, "kafka_key": "54321"}  # пусть
         self.test_items2 = {"topic_key": "12345", "timeout": 10}  # пусть
         self.test_items3 = {"topic_key": "12345", "kafka_replyTopic": "any theme", "timeout": 10}  # пусть
+        self.test_items4 = {"topic_key": "12345", "kafka_replyTopic": "any theme", "timeout": 10, "topic": "topic123"}  # пусть
         self.test_source_mq_message = Mock('source_mq_message')
         self.test_source_mq_message.headers = lambda: [("any header 1", 1)]
 
@@ -23,6 +24,11 @@ class RequestTest1(unittest.TestCase):
             obj2 = kafka_request.SmartKitKafkaRequest("")
         self.assertTrue(obj1._callback_id == 22)
         self.assertTrue(obj1._kafka_replyTopic == "any theme")
+
+    def test_smart_kafka_request_topic(self):
+        obj1 = kafka_request.SmartKitKafkaRequest(self.test_items4)
+        self.assertTrue(obj1.topic_key == "12345")
+        self.assertTrue(obj1.topic == "topic123")
 
     def test_smart_kafka_request_callback_id_header_name(self):
         obj1 = kafka_request.SmartKitKafkaRequest(self.test_items1)

--- a/tests/smart_kit_tests/user/test_user_model.py
+++ b/tests/smart_kit_tests/user/test_user_model.py
@@ -37,7 +37,7 @@ class UserTest2(unittest.TestCase):
     def test_smart_app_user_fields(self):
         obj1 = user_model.User(self.test_id, self.test_message, None, self.test_values, self.test_descriptions,
                                        self.test_parametrizer_cls)
-        self.assertTrue(len(obj1.fields) == 13)
+        self.assertTrue(len(obj1.fields) == 14)
         self.assertTrue(isinstance(obj1.fields[0], Field))
 
     def test_smart_app_user_parametrizer(self):


### PR DESCRIPTION
Если в исходном сообщении в headers приходит ключ "kafka_replyTopic", то "пытаемся" послать ответ в этот топик.

Под "пытаемся" понимается, что если сгенерированный outgoing_request уже содержал в себе топик, например если в action было указано "request_data": {"topic_key": "smth", ...}, то мы посылаем запрос в тот топик, что указан. А вот если знания о том, куда отправлять запрос нет, то посылаем в "kafka_replyTopic". 