### PR TITLE
DPNLPF-1729: add recovery of Kafka message key, refactor check_message_key, reformatting

### DIFF
--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import time
+from typing import Union
 
 from confluent_kafka import Producer
 
@@ -21,11 +22,13 @@ class KafkaPublisher(BaseKafkaPublisher):
         if internal_log_path:
             debug_logger = logging.getLogger("debug_publisher")
             timestamp = time.strftime("_%d%m%Y_")
-            debug_logger.addHandler(logging.FileHandler("{}/kafka_publisher_debug{}{}.log".format(internal_log_path, timestamp, os.getpid())))
+            debug_logger.addHandler(logging.FileHandler(
+                "{}/kafka_publisher_debug{}{}.log".format(internal_log_path, timestamp, os.getpid())
+            ))
             conf["logger"] = debug_logger
         self._producer = Producer(**conf)
 
-    def send(self, value, key=None, topic_key=None, headers=None):
+    def send(self, value: Union[str, bytes], key=None, topic_key=None, headers=None):
         try:
             topic = self._config["topic"]
             if topic_key is not None:

--- a/core/request/kafka_request.py
+++ b/core/request/kafka_request.py
@@ -23,11 +23,12 @@ class KafkaRequest(BaseRequest):
         headers = source_mq_message.headers() or []
         return headers
 
-    def run(self, data, params=None):
+    def run(self, data, params):
         publishers = params["publishers"]
         publisher = publishers[self.kafka_key]
         source_mq_message = params["mq_message"]
-        publisher.send(data, source_mq_message.key(), self.topic_key, headers=self._get_new_headers(source_mq_message))
+        message_key = params["message_key"]
+        publisher.send(data, message_key, self.topic_key, headers=self._get_new_headers(source_mq_message))
 
     def __str__(self):
         return f"KafkaRequest: topic_key={self.topic_key} kafka_key={self.kafka_key}"

--- a/core/request/kafka_request.py
+++ b/core/request/kafka_request.py
@@ -27,8 +27,7 @@ class KafkaRequest(BaseRequest):
         publishers = params["publishers"]
         publisher = publishers[self.kafka_key]
         source_mq_message = params["mq_message"]
-        message_key = params["message_key"]
-        publisher.send(data, message_key, self.topic_key, headers=self._get_new_headers(source_mq_message))
+        publisher.send(data, source_mq_message.key(), self.topic_key, headers=self._get_new_headers(source_mq_message))
 
     def __str__(self):
         return f"KafkaRequest: topic_key={self.topic_key} kafka_key={self.kafka_key}"

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -252,6 +252,7 @@ class MainLoop(BaseMainLoop):
                             log_const.KEY_NAME: "check_kafka_key_validation",
                             MESSAGE_ID_STR: message.incremental_id,
                             UID_STR: message.uid
+                            "class_name": self.__class__.__name__
                         }, user=user,
                         level="WARNING")
                     self.publishers[kafka_key].send_to_topic(message_value, valid_key, mq_message.topic(),

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -261,7 +261,8 @@ class MainLoop(BaseMainLoop):
                         f"resent again with a valid key: '{valid_key}'",
                         params={log_const.KEY_NAME: "kafka_message_key_recovery",
                                 MESSAGE_ID_STR: message.incremental_id,
-                                UID_STR: message.uid},
+                                UID_STR: message.uid,
+                                "class_name": self.__class__.__name__},
                         user=user,
                         level="WARNING")
 

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -246,7 +246,7 @@ class MainLoop(BaseMainLoop):
                                                         uid=message.uid, user=user)
                 valid_key = self._get_valid_message_key(message)
                 if message_key != valid_key:
-                    log(f"MainLoop._log_fail_check_kafka_message_key: Failed to check Kafka message key {message_key} "
+                    log(f"%(class_name)s.process_message: Failed to check Kafka message key {message_key} "
                         f"!= {valid_key}",
                         params={
                             log_const.KEY_NAME: "check_kafka_key_validation",

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -241,7 +241,7 @@ class MainLoop(BaseMainLoop):
                     self.log_fail_check_kafka_message_key(message_key, valid_key, log_params)
                     self.publishers[kafka_key].send(message_value, valid_key, topic_key, mq_message.headers())
                     log(f"Kafka message with invalid Kafka message key '{message_key}' "
-                        f"resent again with new key: '{valid_key}'",
+                        f"resent again with a valid key: '{valid_key}'",
                         params={log_const.KEY_NAME: "kafka_message_key_recovery",
                                 MESSAGE_ID_STR: log_params["incremental_id"],
                                 UID_STR: log_params["uid"]},

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -239,7 +239,8 @@ class MainLoop(BaseMainLoop):
                 valid_key = self._get_valid_message_key(message)
                 if message_key != valid_key:
                     self._log_fail_check_kafka_message_key(message_key, valid_key, log_params)
-                    self.publishers[kafka_key].send(message_value, valid_key, topic_key, mq_message.headers())
+                    self.publishers[kafka_key].send_to_topic(message_value, valid_key, mq_message.topic(),
+                                                             mq_message.headers())
                     self._log_resent_message_replaced_message_key(message_key, valid_key, log_params)
 
                 else:

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -251,7 +251,7 @@ class MainLoop(BaseMainLoop):
                         params={
                             log_const.KEY_NAME: "check_kafka_key_validation",
                             MESSAGE_ID_STR: message.incremental_id,
-                            UID_STR: message.uid
+                            UID_STR: message.uid,
                             "class_name": self.__class__.__name__
                         }, user=user,
                         level="WARNING")

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -257,7 +257,7 @@ class MainLoop(BaseMainLoop):
                         level="WARNING")
                     self.publishers[kafka_key].send_to_topic(message_value, valid_key, mq_message.topic(),
                                                              mq_message.headers())
-                    log(f"Kafka message with invalid Kafka message key '{message_key}' "
+                    log(f"%(class_name)s.process_message: Kafka message with invalid Kafka message key '{message_key}' "
                         f"resent again with a valid key: '{valid_key}'",
                         params={log_const.KEY_NAME: "kafka_message_key_recovery",
                                 MESSAGE_ID_STR: message.incremental_id,


### PR DESCRIPTION
поломка mq_message.key() (т.е. значения ключа сообщения (принимаемого и посылаемого в kafka)) на совести аппа - от этого сложно гарантированно защититься
сейчас когда ответ аппа ломает входящий ему mq_message.key() - дальнейшее взаимодействие так же идет с ломанным mq_message.key()
хотя DP может восстановить правильное значение mq_message.key() из DialogPolicyFromMessage (свойства sub, channel, uid)
необходимо реализовать такую логику

От Макара: добавил восстановаление Kafka message key, отрефакторил check_message_key, дополнительно поправил форматирование и добавил Type-хинты.
Для проверяющего: логика меняется только в четырёх местах, а остальное - форматирование. По изменению логики: self.check_message_key - замена вызова функции на равносильный код; вызов self._send_request - передача необходимых параметров, которые используются для замены Kafka message key на валидную версию; изменение тела self._send_request - замена ключа на валидный; KafkaRequest.run: message_key = params["message_key"] - использование message_key в запросе из параметров.
