### PR TITLE
DPNLPF-1728: fix double message when invalid message key

### DIFF
--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -265,7 +265,7 @@ class MainLoop(BaseMainLoop):
                                 "class_name": self.__class__.__name__},
                         user=user,
                         level="WARNING")
-
+                    break
                 else:
                     log("INCOMING FROM TOPIC: %(topic)s partition %(message_partition)s HEADERS: %(headers)s DATA: "
                         "%(incoming_data)s",


### PR DESCRIPTION
Проблема заключалась в том, что сообщение перепосылалось дважды, если kafka_key был невалидный. Это происходило из-за обертки обработки сообщения в цикле while, который не встречал стоп-условия после пересылки сообщения.
В ПРе был добавлен break для предотвращения повторной обработки сообщения.