### PR TITLE
DPNLPF-1735: Перейти с lazy на cached_property

### DIFF
--- a/core/basic_models/actions/string_actions.py
+++ b/core/basic_models/actions/string_actions.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 import random
 from copy import copy
+from functools import cached_property
 from itertools import chain
 from typing import Union, Dict, List, Any, Optional, Tuple, TypeVar, Type
-
-from lazy import lazy
 
 from core.basic_models.actions.basic_actions import CommandAction
 from core.basic_models.actions.command import Command
@@ -36,11 +35,11 @@ class NodeAction(CommandAction):
         self._support_templates = items.get("support_templates") or {}
         self.no_empty_nodes = items.get("no_empty_nodes", False)
 
-    @lazy
+    @cached_property
     def nodes(self) -> Dict[str, Union[str, T]]:
         return {k: self._get_template_tree(t) for k, t in self._nodes.items()}
 
-    @lazy
+    @cached_property
     def support_templates(self) -> Dict[str, Union[str, T]]:
         return {k: self._get_template_tree(t) for k, t in self._support_templates.items()}
 

--- a/core/basic_models/classifiers/basic_classifiers.py
+++ b/core/basic_models/classifiers/basic_classifiers.py
@@ -2,10 +2,10 @@ import inspect
 import pickle
 import sys
 from abc import ABC, abstractmethod
+from functools import cached_property
 from typing import Any, Dict, Optional, Union, List
 
 import numpy as np
-from lazy import lazy
 from timeout_decorator import timeout_decorator
 
 import core.basic_models.classifiers.classifiers_constants as cls_const
@@ -147,7 +147,7 @@ class ExtendedClassifier(Classifier):
     def set_classifier(self, clsf: Classifier) -> None:
         self._classifier = clsf
 
-    @lazy
+    @cached_property
     def classifier(self) -> Classifier:
         return self._classifier
 

--- a/core/basic_models/parametrizers/parametrizer.py
+++ b/core/basic_models/parametrizers/parametrizer.py
@@ -1,6 +1,5 @@
+from functools import cached_property
 from typing import TypeVar, Dict, Any
-
-from lazy import lazy
 
 from core.basic_models.parametrizers.filter import Filter
 
@@ -12,7 +11,7 @@ class BasicParametrizer:
         self._user = user
         self._filter = items.get("filter") or {}
 
-    @lazy
+    @cached_property
     def filter(self):
         return Filter(self._filter)
 

--- a/core/basic_models/requirement/basic_requirements.py
+++ b/core/basic_models/requirement/basic_requirements.py
@@ -1,10 +1,10 @@
 import hashlib
 from datetime import datetime, timezone
+from functools import cached_property
 from random import random
 from typing import List, Optional, Dict, Any
 
 from croniter import croniter
-from lazy import lazy
 
 import core.logging.logger_constants as log_const
 from core.basic_models.classifiers.basic_classifiers import Classifier, ExternalClassifier
@@ -272,7 +272,7 @@ class ClassifierRequirement(Requirement):
         super(ClassifierRequirement, self).__init__(items=items, id=id)
         self._classifier = items["classifier"]
 
-    @lazy
+    @cached_property
     def classifier(self) -> Classifier:
         return ExternalClassifier(self._classifier)
 

--- a/core/basic_models/requirement/device_requirements.py
+++ b/core/basic_models/requirement/device_requirements.py
@@ -2,7 +2,6 @@
 from core.model.base_user import BaseUser
 from core.text_preprocessing.preprocessing_result import TextPreprocessingResult
 from core.utils.utils import convert_version_to_list_of_int
-from lazy import lazy
 from typing import List, Optional, Dict, Any
 
 from core.model.factory import factory

--- a/core/message/app_info.py
+++ b/core/message/app_info.py
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 from core.names import field
 
@@ -8,26 +8,26 @@ class AppInfo:
     def __init__(self, value):
         self._value = value
 
-    @lazy
+    @cached_property
     def project_id(self):
         return self._value.get(field.PROJECT_ID)
 
-    @lazy
+    @cached_property
     def system_name(self):
         return self._value.get(field.SYSTEM_NAME)
 
-    @lazy
+    @cached_property
     def application_id(self):
         return self._value.get(field.APPLICATION_ID)
 
-    @lazy
+    @cached_property
     def app_version_id(self):
         return self._value.get(field.APP_VERSION_ID)
 
-    @lazy
+    @cached_property
     def frontend_endpoint(self):
         return self._value.get(field.FRONTEND_ENDPOINT)
 
-    @lazy
+    @cached_property
     def frontend_type(self):
         return self._value.get(field.FRONTEND_TYPE)

--- a/core/message/device.py
+++ b/core/message/device.py
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 
 class Device:
@@ -6,42 +6,42 @@ class Device:
     def __init__(self, value):
         self._value = value
 
-    @lazy
+    @cached_property
     def value(self):
         return self._value
 
-    @lazy
+    @cached_property
     def platform_type(self):
         return self._value.get("platformType") or ""
 
-    @lazy
+    @cached_property
     def platform_version(self):
         return self._value.get("platformVersion") or ""
 
-    @lazy
+    @cached_property
     def surface(self):
         return self._value.get("surface") or ""
 
-    @lazy
+    @cached_property
     def surface_version(self):
         return self._value.get("surfaceVersion") or ""
 
-    @lazy
+    @cached_property
     def features(self):
         return self._value.get("features") or {}
 
-    @lazy
+    @cached_property
     def capabilities(self):
         return self._value.get("capabilities") or {}
 
-    @lazy
+    @cached_property
     def additional_info(self):
         return self._value.get("additionalInfo") or {}
 
-    @lazy
+    @cached_property
     def tenant(self):
         return self._value.get("tenant") or ""
 
-    @lazy
+    @cached_property
     def device_id(self):
         return self._value.get("deviceId") or ""

--- a/core/message/from_message.py
+++ b/core/message/from_message.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 from typing import Iterable
-from lazy import lazy
 import json
 import uuid
 

--- a/core/model/base_user.py
+++ b/core/model/base_user.py
@@ -1,8 +1,7 @@
 # coding: utf-8
 import json
+from functools import cached_property
 from typing import List
-
-from lazy import lazy
 
 from core.descriptions.descriptions import Descriptions
 from core.model.queued_objects.limited_queued_hashable_objects_description import \
@@ -39,7 +38,7 @@ class BaseUser(Model):
         """Add here some things to do after creating fields."""
         pass
 
-    @lazy
+    @cached_property
     def parametrizer(self):
         return BasicParametrizer(self, {})
 

--- a/scenarios/actions/action.py
+++ b/scenarios/actions/action.py
@@ -1,10 +1,6 @@
-import collections
 import copy
-import json
 import time
-
-from lazy import lazy
-from jinja2 import exceptions as jexcept
+from functools import cached_property
 from typing import Optional, Dict, Any, Union, List
 
 from core.basic_models.actions.basic_actions import Action
@@ -22,7 +18,7 @@ from core.utils.pickle_copy import pickle_deepcopy
 
 import scenarios.logging.logger_constants as log_const
 from scenarios.actions.action_params_names import TO_MESSAGE_NAME, TO_MESSAGE_PARAMS, SAVED_MESSAGES, \
-    REQUEST_FIELD, LOCAL_VARS
+    REQUEST_FIELD
 from scenarios.user.parametrizer import Parametrizer
 from scenarios.user.user_model import User
 from scenarios.scenario_models.history import Event
@@ -140,11 +136,11 @@ class BasicSelfServiceActionWithState(StringAction):
         self._check_scenario: bool = items.get("check_scenario", True)
         super(BasicSelfServiceActionWithState, self).__init__(self._command_action, id)
 
-    @lazy
+    @cached_property
     def behavior_action(self) -> SaveBehaviorAction:
         return SaveBehaviorAction({"behavior": self.behavior, "check_scenario": self._check_scenario})
 
-    @lazy
+    @cached_property
     def command_action(self) -> StringAction:
         return StringAction(self._command_action)
 

--- a/scenarios/behaviors/behavior_description.py
+++ b/scenarios/behaviors/behavior_description.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import time
-
-from lazy import lazy
+from functools import cached_property
 
 from core.basic_models.actions.basic_actions import Action
 from core.model.factory import factory
@@ -25,22 +24,22 @@ class BehaviorDescription:
         setting_timeout = user.settings["template_settings"].get("services_timeout", {}).get(self.id)
         return setting_timeout or self._timeout
 
-    @lazy
+    @cached_property
     @factory(Action)
     def success_action(self):
         return self._success_action
 
-    @lazy
+    @cached_property
     @factory(Action)
     def fail_action(self):
         return self._fail_action
 
-    @lazy
+    @cached_property
     @factory(Action)
     def misstate(self):
         return self._misstate
 
-    @lazy
+    @cached_property
     @factory(Action)
     def timeout_action(self):
         return self._timeout_action

--- a/scenarios/scenario_descriptions/tree_scenario/tree_scenario.py
+++ b/scenarios/scenario_descriptions/tree_scenario/tree_scenario.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from lazy import lazy
 from typing import Dict, Any
 
 from scenarios.scenario_descriptions.form_filling_scenario import FormFillingScenario

--- a/scenarios/scenario_descriptions/tree_scenario/tree_scenario_node.py
+++ b/scenarios/scenario_descriptions/tree_scenario/tree_scenario_node.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from lazy import lazy
+from functools import cached_property
 
 from core.basic_models.actions.basic_actions import Action
 from core.basic_models.requirement.basic_requirements import Requirement
@@ -15,12 +15,12 @@ class TreeScenarioNode:
         self._actions = items.get("actions")
         self.available_nodes = items.get("available_nodes")
 
-    @lazy
+    @cached_property
     @factory(Requirement)
     def requirement(self):
         return self._requirement
 
-    @lazy
+    @cached_property
     @list_factory(Action)
     def actions(self):
         return self._actions

--- a/scenarios/scenario_models/field/field_descriptions/basic_field_description.py
+++ b/scenarios/scenario_models/field/field_descriptions/basic_field_description.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from lazy import lazy
+from functools import cached_property
 
 from core.basic_models.actions.basic_actions import Action
 from core.basic_models.requirement.basic_requirements import Requirement
@@ -33,12 +33,12 @@ class BasicFieldDescription:
         self.fill_other = items.get("fill_other", True)
         self._ask_again_requests = items.get("ask_again_questions", [])
 
-    @lazy
+    @cached_property
     @list_factory(Action)
     def requests(self):
         return self._requests
 
-    @lazy
+    @cached_property
     @list_factory(Action)
     def on_filled_actions(self):
         return self._on_filled_actions
@@ -51,17 +51,17 @@ class BasicFieldDescription:
     def required(self):
         return self._required
 
-    @lazy
+    @cached_property
     @factory(Requirement)
     def requirement(self):
         return self._requirement
 
-    @lazy
+    @cached_property
     @factory(FieldFillerDescription)
     def filler(self):
         return self._filler
 
-    @lazy
+    @cached_property
     @factory(FieldValidator)
     def field_validator(self):
         return self._field_validator

--- a/scenarios/scenario_models/field/field_descriptions/composite_field_description.py
+++ b/scenarios/scenario_models/field/field_descriptions/composite_field_description.py
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 from core.model.factory import dict_factory, factory
 from scenarios.scenario_models.field.field_filler_description import FieldFillerDescription
@@ -11,12 +11,12 @@ class CompositeFieldDescription(BasicFieldDescription):
         super(CompositeFieldDescription, self).__init__(items, id)
         self._fields = items["fields"]
 
-    @lazy
+    @cached_property
     @factory(FieldFillerDescription)
     def filler(self):
         return self._filler
 
-    @lazy
+    @cached_property
     @dict_factory(BasicFieldDescription)
     def fields(self):
         return self._fields

--- a/scenarios/scenario_models/field/field_descriptions/integration_field_description.py
+++ b/scenarios/scenario_models/field/field_descriptions/integration_field_description.py
@@ -1,9 +1,4 @@
 # coding: utf-8
-from lazy import lazy
-
-from core.basic_models.requirement.basic_requirements import Requirement
-from core.model.factory import factory
-
 from scenarios.scenario_models.field.field_descriptions.basic_field_description import BasicFieldDescription
 
 

--- a/scenarios/scenario_models/field/field_descriptions/question_field_description.py
+++ b/scenarios/scenario_models/field/field_descriptions/question_field_description.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from lazy import lazy
+from functools import cached_property
 
 from core.basic_models.actions.basic_actions import Action
 from core.model.factory import list_factory
@@ -16,7 +16,7 @@ class QuestionFieldDescription(BasicFieldDescription):
         self._on_filled_actions = items.get("on_filled_actions", [])
         self._ask_again_requests = items.get("ask_again_questions", [])
 
-    @lazy
+    @cached_property
     @list_factory(Action)
     def ask_again_requests(self):
         return self._ask_again_requests

--- a/scenarios/scenario_models/field/field_filler_description.py
+++ b/scenarios/scenario_models/field/field_filler_description.py
@@ -2,11 +2,11 @@ import collections
 import json
 import operator
 import re
+from functools import cached_property
 from itertools import islice
 from typing import Dict, List, Union, Optional, Any, Callable, Pattern, Set
 
 from jinja2 import exceptions as jexcept
-from lazy import lazy
 
 import core.basic_models.classifiers.classifiers_constants as cls_const
 import core.logging.logger_constants as core_log_const
@@ -543,7 +543,7 @@ class ClassifierFiller(FieldFillerDescription):
         self._classifier = items["classifier"]
         self._cls_const_answer_key = cls_const.ANSWER_KEY
 
-    @lazy
+    @cached_property
     def classifier(self) -> Classifier:
         return ExternalClassifier(self._classifier)
 

--- a/scenarios/scenario_models/history/history_description.py
+++ b/scenarios/scenario_models/history/history_description.py
@@ -1,5 +1,5 @@
+from functools import cached_property
 from typing import Union
-from lazy import lazy
 
 from core.model.factory import factory
 from scenarios.scenario_models.history import EventFormatter
@@ -17,7 +17,7 @@ class HistoryDescription:
         self.event_expiration_delay = items.get("event_expiration_delay", self.EVENT_EXPIRATION_DELAY)
         self._formatter = items.get("formatter")
 
-    @lazy
+    @cached_property
     @factory(EventFormatter)
     def formatter(self) -> EventFormatter:
         return self._formatter

--- a/scenarios/user/last_scenarios/last_scenarios_description.py
+++ b/scenarios/user/last_scenarios/last_scenarios_description.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from lazy import lazy
+from functools import cached_property
 
 from core.basic_models.requirement.basic_requirements import Requirement
 from core.model.factory import factory
@@ -12,7 +12,7 @@ class LastScenariosDescription:
         self._requirement = items.get("requirement")
         self.count = items.get("count", 1)
 
-    @lazy
+    @cached_property
     @factory(Requirement)
     def requirement(self):
         return self._requirement

--- a/scenarios/user/reply_selector/reply_selector.py
+++ b/scenarios/user/reply_selector/reply_selector.py
@@ -1,6 +1,5 @@
 import random
 from typing import Dict, Any
-from lazy import lazy
 
 from core.model.base_user import BaseUser as User
 from core.unified_template.unified_template import UnifiedTemplate

--- a/scenarios/user/user_model.py
+++ b/scenarios/user/user_model.py
@@ -1,5 +1,5 @@
 import json
-from lazy import lazy
+from functools import cached_property
 
 from core.logging.logger_utils import log
 from core.model.field import Field
@@ -63,7 +63,7 @@ class User(BaseUser):
                                  Field("history", History, self.descriptions["history"]),
                                  Field("gender_selector", ReplySelector)]
 
-    @lazy
+    @cached_property
     def parametrizer(self):
         return self.__parametrizer_cls(self, {})
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         "ics==0.6",
         "Jinja2==3.0.3",
         "keras>=2.6.0",
-        "lazy",
         "nltk==3.5",
         "numpy",
         "objgraph==3.4.1",

--- a/smart_kit/message/app_info.py
+++ b/smart_kit/message/app_info.py
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 from core.names import field
 
@@ -8,26 +8,26 @@ class AppInfo:
     def __init__(self, value):
         self._value = value
 
-    @lazy
+    @cached_property
     def project_id(self):
         return self._value.get(field.PROJECT_ID)
 
-    @lazy
+    @cached_property
     def system_name(self):
         return self._value.get(field.SYSTEM_NAME)
 
-    @lazy
+    @cached_property
     def application_id(self):
         return self._value.get(field.APPLICATION_ID)
 
-    @lazy
+    @cached_property
     def app_version_id(self):
         return self._value.get(field.APP_VERSION_ID)
 
-    @lazy
+    @cached_property
     def frontend_endpoint(self):
         return self._value.get(field.FRONTEND_ENDPOINT)
 
-    @lazy
+    @cached_property
     def frontend_type(self):
         return self._value.get(field.FRONTEND_TYPE)

--- a/smart_kit/message/as_is_to_message.py
+++ b/smart_kit/message/as_is_to_message.py
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 from core.message.from_message import SmartAppFromMessage
 from smart_kit.message.smartapp_to_message import SmartAppToMessage
@@ -6,7 +6,7 @@ from smart_kit.message.smartapp_to_message import SmartAppToMessage
 
 class AsIsToMessage(SmartAppToMessage):
 
-    @lazy
+    @cached_property
     def as_dict(self):
         self.incoming_message: SmartAppFromMessage
         fields = self.command.raw

--- a/smart_kit/message/smartapp_to_message.py
+++ b/smart_kit/message/smartapp_to_message.py
@@ -1,6 +1,6 @@
+from functools import cached_property
 from typing import Iterable
 import json
-from lazy import lazy
 from copy import copy
 
 from core.utils.masking_message import masking
@@ -23,7 +23,7 @@ class SmartAppToMessage:
         self.masking_fields = masking_fields
         self.validators = validators
 
-    @lazy
+    @cached_property
     def payload(self):
         payload = copy(self.command.payload)
         for field in self.forward_fields:
@@ -34,7 +34,7 @@ class SmartAppToMessage:
             payload[field] = self.incoming_message.payload[field]
         return payload
 
-    @lazy
+    @cached_property
     def as_dict(self):
         fields = {
             "messageId": self.incoming_message.incremental_id,
@@ -58,7 +58,7 @@ class SmartAppToMessage:
         uuid.userChannel = data_as_dict["uuid"]["userChannel"]
         return message
 
-    @lazy
+    @cached_property
     def masked_value(self):
         masked_data = masking(self.as_dict, self.masking_fields)
         if self.command.loader == "json.dumps":
@@ -67,7 +67,7 @@ class SmartAppToMessage:
             protobuf_message = self.as_protobuf_message(masked_data)
             return protobuf_message.SerializeToString()
 
-    @lazy
+    @cached_property
     def value(self):
         if self.command.loader == "json.dumps":
             return json.dumps(self.as_dict, ensure_ascii=False)

--- a/smart_kit/models/dialogue_manager.py
+++ b/smart_kit/models/dialogue_manager.py
@@ -1,9 +1,10 @@
 # coding: utf-8
+from functools import cached_property
+
 from core.logging.logger_utils import log
 from core.names import field
 
 import scenarios.logging.logger_constants as log_const
-from lazy import lazy
 
 from scenarios.scenario_descriptions.form_filling_scenario import FormFillingScenario
 from smart_kit.system_answers.nothing_found_action import NothingFoundAction
@@ -22,7 +23,7 @@ class DialogueManager:
         self.app_name = app_name
         log(f"{self.__class__.__name__}.__init__ finished.", params={log_const.KEY_NAME: log_const.STARTUP_VALUE})
 
-    @lazy
+    @cached_property
     def _nothing_found_action(self):
         return self.actions.get(self.NOTHING_FOUND_ACTION) or NothingFoundAction()
 

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -2,12 +2,11 @@
 import json
 import time
 from collections import namedtuple
-from functools import lru_cache
+from functools import lru_cache, cached_property
 from typing import Union
 from typing import Optional
 
 from confluent_kafka.cimpl import KafkaException, Message as KafkaMessage
-from lazy import lazy
 
 import scenarios.logging.logger_constants as log_const
 from core.configs.global_constants import KAFKA_REPLY_TOPIC
@@ -456,7 +455,7 @@ class MainLoop(BaseMainLoop):
     def default_topic_key(self, kafka_key):
         return self.settings["kafka"]["template-engine"][kafka_key].get("default_topic_key")
 
-    @lazy
+    @cached_property
     def masking_fields(self):
         return self.settings["template_settings"].get("masking_fields")
 

--- a/smart_kit/template/app/user/user.py-tpl
+++ b/smart_kit/template/app/user/user.py-tpl
@@ -1,4 +1,4 @@
-from lazy import lazy
+from functools import cached_property
 
 from scenarios.user.user_model import User
 
@@ -20,7 +20,7 @@ class CustomeUser(User):
     def fields(self):
         return super(CustomeUser, self).fields + []
 
-    @lazy
+    @cached_property
     def parametrizer(self):
         return CustomParametrizer(self, {})
 

--- a/smart_kit/testing/local.py
+++ b/smart_kit/testing/local.py
@@ -3,8 +3,7 @@ import json
 import os
 import pprint
 import typing
-
-from lazy import lazy
+from functools import cached_property
 
 from core.descriptions.descriptions import Descriptions
 from core.message.from_message import SmartAppFromMessage
@@ -53,17 +52,17 @@ class CLInterface(cmd.Cmd):
         callback = getattr(self, f"on_{message.name.lower()}", lambda *args, **kwargs: None)
         return callback(message)
 
-    @lazy
+    @cached_property
     def app_model(self):
         return self.__model_cls(self.resources, self.__dialogue_manager_cls, custom_settings=self.settings)
 
-    @lazy
+    @cached_property
     def resources(self):
         source = self.settings.get_source()
 
         return self.__resources_cls(source, self.references_path, self.settings)
 
-    @lazy
+    @cached_property
     def available_scenarios(self):
         return list(Descriptions(self.resources.registered_repositories)["scenarios"].keys())
 

--- a/smart_kit/testing/suite.py
+++ b/smart_kit/testing/suite.py
@@ -1,9 +1,8 @@
 import json
 import os
 from csv import DictWriter, QUOTE_MINIMAL
+from functools import cached_property
 from typing import AnyStr, Optional, Tuple, Any, Dict, Callable
-
-from lazy import lazy
 
 from core.configs.global_constants import LINK_BEHAVIOR_FLAG
 from smart_kit.compatibility.commands import combine_commands
@@ -80,20 +79,20 @@ class TestSuite:
         with open(predefined_fields_storage, "r") as f:
             self.storaged_predefined_fields = json.load(f)
 
-    @lazy
+    @cached_property
     def app_model(self):
         return self.app_config.MODEL(
             self.resources, self.app_config.DIALOGUE_MANAGER, custom_settings=self.settings,
             app_name=self.app_config.APP_NAME
         )
 
-    @lazy
+    @cached_property
     def resources(self):
         source = self.settings.get_source()
 
         return self.app_config.RESOURCES(source, self.app_config.REFERENCES_PATH, self.settings)
 
-    @lazy
+    @cached_property
     def settings(self):
         return self.app_config.SETTINGS(config_path=self.app_config.CONFIGS_PATH,
                                         secret_path=self.app_config.SECRET_PATH,

--- a/smart_kit/text_preprocessing/local_text_normalizer.py
+++ b/smart_kit/text_preprocessing/local_text_normalizer.py
@@ -1,7 +1,7 @@
+from functools import cached_property
 from typing import List, Sequence
 
 import nltk
-from lazy import lazy
 from rusenttokenize import ru_sent_tokenize
 
 from core.repositories.file_repository import FileRepository
@@ -28,7 +28,7 @@ class LocalTextNormalizer(BaseTextNormalizer, metaclass=Singleton):
         self.__ready_to_use = False
         self._morph = None
 
-    @lazy
+    @cached_property
     def morph(self):
         self._morph = Pymorphy2MorphWrapper()
         return self._morph


### PR DESCRIPTION
Заменить декоратор lazy (from lazy import lazy)
на декоратор cached_property (from functools import cached_property)
Поскольку при использовании lazy не работает type hinting, а при cached_property работает
Пример кода, где mypy не найдет ошибку:
from lazy import lazy


class Clazz:
    def __init__(self, a: int, b: int):
        self.a = a
        self.b = b

    @lazy
    def sum_prop(self) -> int:
        return self.a + self.b


def main() -> None:
    inst = Clazz(1, 2)
    res: str = inst.sum_prop
    print(res)


if __name__ == '__main__':
    main()

Пример кода, где mypy найдет ошибку:
from functools import cached_property


class Clazz:
    def __init__(self, a: int, b: int):
        self.a = a
        self.b = b

    @cached_property
    def sum_prop(self) -> int:
        return self.a + self.b


def main() -> None:
    inst = Clazz(1, 2)
    res: str = inst.sum_prop
    print(res)


if __name__ == '__main__':
    main()
    
   
От Макара: заменил все использования @lazy на @cached_property, почистил импорты и рекваирменты