### PR TITLE
DPNLPF-1842: change kafka key log fields

### DIFF
--- a/smart_kit/template/static/configs/template_config.yml
+++ b/smart_kit/template/static/configs/template_config.yml
@@ -20,3 +20,4 @@ user_save_collisions_tries: 2
 self_service_with_state_save_messages: true
 project_id: template-app-id
 consumer_topic: "app"
+kafka_message_key_recovery_log_level: "WARNING"


### PR DESCRIPTION
улучшить логгирование при поломке ключа кафки

- в запись лога с key_name = check_kafka_key_validation убрать запись поля args.data как избыточное
- в запись лога с key_name = kafka_message_key_recovery убрать запись поля args.data как избыточное
- запись лога с key_name = kafka_message_key_recovery перенести на levelname=DEBUG как избыточное для отладки в проме