### PR TITLE
DPNLPF-1842: fix kafka_message_key_recovery_log_level

### DIFF
--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -268,7 +268,7 @@ class MainLoop(BaseMainLoop):
                                 "message_name": message.type,
                             }, user=user,
                             level=self.settings["template_settings"].get("kafka_message_key_recovery_log_level",
-                                                                         "WARNING"))
+                                                                         "DEBUG"))
                         break
                 else:
                     log("INCOMING FROM TOPIC: %(topic)s partition %(message_partition)s HEADERS: %(headers)s DATA: "

--- a/smart_kit/template/static/configs/template_config.yml
+++ b/smart_kit/template/static/configs/template_config.yml
@@ -20,4 +20,4 @@ user_save_collisions_tries: 2
 self_service_with_state_save_messages: true
 project_id: template-app-id
 consumer_topic: "app"
-kafka_message_key_recovery_log_level: "WARNING"
+kafka_message_key_recovery_log_level: "DEBUG"


### PR DESCRIPTION
запись лога с key_name = kafka_message_key_recovery перенести на levelname=DEBUG как избыточное для отладки в проме