### PR TITLE
Fix outgoing log message

### DIFF
--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -444,7 +444,7 @@ class MainLoop(BaseMainLoop):
     def _log_request(self, user, request, answer, original_mq_message):
         log("OUTGOING TO TOPIC_KEY: %(topic_key)s DATA: %(data)s",
             params={log_const.KEY_NAME: "outgoing_message",
-                    "topic": request.topic_key,
+                    "topic_key": request.topic_key,
                     "headers": request._get_new_headers(original_mq_message),
                     "data": answer.masked_value,
                     "length": len(answer.value),


### PR DESCRIPTION
+ fixed `topic_key` in log message (KeyError)

we've lost a key name some where
https://github.com/salute-developers/smart_app_framework/blob/v1.0.7rc22/smart_kit/start_points/main_loop_kafka.py#L403-L405