### PR TITLE
DPNLPF-1910: support none as answer of actions and handlers

### DIFF
--- a/core/basic_models/scenarios/base_scenario.py
+++ b/core/basic_models/scenarios/base_scenario.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from typing import Dict, Any, List, Union, Optional
+from typing import Dict, Any, List
 
 import core.logging.logger_constants as log_const
 import scenarios.logging.logger_constants as scenarios_log_const
@@ -84,7 +84,7 @@ class BaseScenario:
                            actions: List[Action], params: Dict[str, Any] = None) -> List[Command]:
         results = []
         for action in actions:
-            result = action.run(user, text_preprocessing_result, params)
+            result = action.run(user, text_preprocessing_result, params) or []
             log_params = self._log_params()
             log_params["class"] = action.__class__.__name__
             log("called action: %(class)s", user, log_params)

--- a/scenarios/actions/action.py
+++ b/scenarios/actions/action.py
@@ -161,7 +161,7 @@ class BasicSelfServiceActionWithState(StringAction):
 
     def _run(self, user, text_preprocessing_result, params=None) -> List[Command]:
         self.behavior_action.run(user, text_preprocessing_result, params)
-        command_action_result = self.command_action.run(user, text_preprocessing_result, params)
+        command_action_result = self.command_action.run(user, text_preprocessing_result, params) or []
         return command_action_result
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
@@ -290,7 +290,7 @@ class ChoiceScenarioAction(Action):
                 break
 
         if not choice_is_made and self._else_item:
-            commands.extend(self.else_item.run(user, text_preprocessing_result, params))
+            commands.extend(self.else_item.run(user, text_preprocessing_result, params) or [])
 
         return commands
 

--- a/scenarios/behaviors/behaviors.py
+++ b/scenarios/behaviors/behaviors.py
@@ -142,7 +142,7 @@ class Behaviors:
                 callback_action_params,
             )
             text_preprocessing_result = TextPreprocessingResult(callback.text_preprocessing_result)
-            result = behavior.success_action.run(self._user, text_preprocessing_result, callback_action_params)
+            result = behavior.success_action.run(self._user, text_preprocessing_result, callback_action_params) or []
         else:
             log(f"behavior.success not found valid callback for callback_id {callback_id}",
                 self._user,
@@ -163,7 +163,7 @@ class Behaviors:
                                monitoring.counter_behavior_fail, "fail",
                                callback_action_params)
             text_preprocessing_result = TextPreprocessingResult(callback.text_preprocessing_result)
-            result = behavior.fail_action.run(self._user, text_preprocessing_result, callback_action_params)
+            result = behavior.fail_action.run(self._user, text_preprocessing_result, callback_action_params) or []
         else:
             log(f"behavior.fail not found valid callback for callback_id {callback_id}",
                 self._user,
@@ -183,7 +183,7 @@ class Behaviors:
                                monitoring.counter_behavior_timeout, "timeout",
                                callback_action_params)
             text_preprocessing_result = TextPreprocessingResult(callback.text_preprocessing_result)
-            result = behavior.timeout_action.run(self._user, text_preprocessing_result, callback_action_params)
+            result = behavior.timeout_action.run(self._user, text_preprocessing_result, callback_action_params) or []
         else:
             log(f"behavior.timeout not found valid callback for callback_id {callback_id}",
                 self._user,

--- a/scenarios/scenario_descriptions/form_filling_scenario.py
+++ b/scenarios/scenario_descriptions/form_filling_scenario.py
@@ -1,6 +1,7 @@
 # coding: utf-8
-from typing import Dict, Any
+from typing import Dict, Any, Tuple, List
 
+from core.basic_models.actions.command import Command
 from core.basic_models.scenarios.base_scenario import BaseScenario
 from core.monitoring.monitoring import monitoring
 from core.logging.logger_utils import log
@@ -113,7 +114,7 @@ class FormFillingScenario(BaseScenario):
                                                                 text_normalization_result, user, params))
         return result
 
-    def _validate_extracted_data(self, user, text_preprocessing_result, form, data_extracted, params):
+    def _validate_extracted_data(self, user, text_preprocessing_result, form, data_extracted, params) -> List[Command]:
         error_msgs = []
         for field_key, field in form.description.fields.items():
             value = data_extracted.get(field_key)
@@ -130,7 +131,7 @@ class FormFillingScenario(BaseScenario):
                 break
         return error_msgs
 
-    def _fill_form(self, user, text_preprocessing_result, form, data_extracted):
+    def _fill_form(self, user, text_preprocessing_result, form, data_extracted) -> Tuple[List[Command], bool]:
         on_filled_actions = []
         fields = form.fields
         scenario_model = user.scenario_models[self.id]
@@ -148,7 +149,7 @@ class FormFillingScenario(BaseScenario):
                     return _action, is_break
         return on_filled_actions, is_break
 
-    def get_reply(self, user, text_preprocessing_result, reply_actions, field, form):
+    def get_reply(self, user, text_preprocessing_result, reply_actions, field, form) -> List[Command]:
         action_params = {}
         if field:
             field.set_available()
@@ -175,7 +176,7 @@ class FormFillingScenario(BaseScenario):
         return action_messages
 
     @monitoring.got_histogram("scenario_time")
-    def run(self, text_preprocessing_result, user, params: Dict[str, Any] = None):
+    def run(self, text_preprocessing_result, user, params: Dict[str, Any] = None) -> List[Command]:
         form = self._get_form(user)
         user.last_scenarios.add(self.id, text_preprocessing_result)
         user.preprocessing_messages_for_scenarios.add(text_preprocessing_result)
@@ -185,7 +186,8 @@ class FormFillingScenario(BaseScenario):
         logging_params.update(self._log_params())
         log("Extracted data=%(data_extracted_str)s", user, logging_params)
 
-        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted, params)
+        validation_error_msg = self._validate_extracted_data(user, text_preprocessing_result, form, data_extracted,
+                                                             params)
         if validation_error_msg:
             reply_messages = validation_error_msg
         else:

--- a/scenarios/scenario_descriptions/tree_scenario/tree_scenario.py
+++ b/scenarios/scenario_descriptions/tree_scenario/tree_scenario.py
@@ -1,6 +1,7 @@
 # coding: utf-8
-from typing import Dict, Any
+from typing import Dict, Any, List
 
+from core.basic_models.actions.command import Command
 from scenarios.scenario_descriptions.form_filling_scenario import FormFillingScenario
 from scenarios.scenario_descriptions.tree_scenario.tree_scenario_node import TreeScenarioNode
 from core.model.factory import dict_factory
@@ -84,7 +85,7 @@ class TreeScenario(FormFillingScenario):
         return all_forms_fields
 
     @monitoring.got_histogram("scenario_time")
-    def run(self, text_preprocessing_result, user, params: Dict[str, Any] = None):
+    def run(self, text_preprocessing_result, user, params: Dict[str, Any] = None) -> List[Command]:
         main_form = self._get_form(user)
         user.last_scenarios.add(self.id, text_preprocessing_result)
         user.preprocessing_messages_for_scenarios.add(text_preprocessing_result)

--- a/smart_kit/handlers/handle_respond.py
+++ b/smart_kit/handlers/handle_respond.py
@@ -59,7 +59,7 @@ class HandlerRespond(HandlerBase):
             log("text preprocessing result: '%(normalized_text)s'", user, params, level="DEBUG")
 
         action = user.descriptions["external_actions"][action_name]
-        commands.extend(action.run(user, text_preprocessing_result, action_params))
+        commands.extend(action.run(user, text_preprocessing_result, action_params) or [])
         return commands
 
     @staticmethod

--- a/smart_kit/handlers/handle_server_action.py
+++ b/smart_kit/handlers/handle_server_action.py
@@ -40,5 +40,5 @@ class HandlerServerAction(HandlerBase):
 
         action_id = self.get_action_name(payload, user)
         action = user.descriptions["external_actions"][action_id]
-        commands.extend(action.run(user, TextPreprocessingResult({}), action_params))
+        commands.extend(action.run(user, TextPreprocessingResult({}), action_params) or [])
         return commands

--- a/smart_kit/handlers/handle_take_runtime_permissions.py
+++ b/smart_kit/handlers/handle_take_runtime_permissions.py
@@ -1,3 +1,6 @@
+from typing import List
+
+from core.basic_models.actions.command import Command
 from core.logging.logger_utils import log
 from scenarios.user.user_model import User
 
@@ -8,13 +11,13 @@ from smart_kit.names.field import STATUS_CODE, CODE, PERMITTED_ACTIONS
 class HandlerTakeRuntimePermissions(HandlerBase):
     SUCCESS_CODE = 1
 
-    def run(self, payload, user: User):
-        super().run(payload, user)
+    def run(self, payload, user: User) -> List[Command]:
+        commands = super().run(payload, user)
         log(f"{self.__class__.__name__} started", user)
         if payload.get(STATUS_CODE, {}).get(CODE) == self.SUCCESS_CODE:
-            commands = user.behaviors.success(user.message.callback_id)
+            commands.extend(user.behaviors.success(user.message.callback_id))
             user.variables.set("permitted_actions", payload.get(PERMITTED_ACTIONS, []))
         else:
-            commands = user.behaviors.fail(user.message.callback_id)
+            commands.extend(user.behaviors.fail(user.message.callback_id))
         user.variables.set("take_runtime_permissions_status_code", payload.get(STATUS_CODE, {}))
         return commands

--- a/smart_kit/handlers/handler_base.py
+++ b/smart_kit/handlers/handler_base.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from core.basic_models.actions.command import Command
 from core.monitoring.monitoring import monitoring
@@ -13,7 +13,7 @@ class HandlerBase:
     def __init__(self, app_name: str):
         self.app_name = app_name
 
-    def run(self, payload: Dict[str, Any], user: User) -> List[Command]:
+    def run(self, payload: Dict[str, Any], user: User) -> Optional[List[Command]]:
         # отправка события о входящем сообщении в систему мониторинга
         monitoring.counter_incoming(self.app_name, user.message.message_name, self.__class__.__name__,
                                     user, app_info=user.message.app_info)

--- a/smart_kit/models/smartapp_model.py
+++ b/smart_kit/models/smartapp_model.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 import sys
 import traceback
+from typing import List, Optional
 
+from core.basic_models.actions.command import Command
 from core.descriptions.descriptions import Descriptions
 from core.logging.logger_utils import log
 from core.utils.exception_handlers import exc_handler
@@ -9,6 +11,7 @@ from core.utils.exception_handlers import exc_handler
 import scenarios.logging.logger_constants as log_const
 from smart_kit.handlers.handle_close_app import HandlerCloseApp
 from smart_kit.handlers.handle_take_runtime_permissions import HandlerTakeRuntimePermissions
+from smart_kit.handlers.handler_base import HandlerBase
 from smart_kit.handlers.handler_take_profile_data import HandlerTakeProfileData
 from smart_kit.names.message_names import MESSAGE_TO_SKILL, LOCAL_TIMEOUT, RUN_APP, SERVER_ACTION, CLOSE_APP, \
     TAKE_PROFILE_DATA, TAKE_RUNTIME_PERMISSIONS
@@ -58,7 +61,7 @@ class SmartAppModel:
             f"{self.__class__.__name__}.__init__ finished.", params={log_const.KEY_NAME: log_const.STARTUP_VALUE}
         )
 
-    def get_handler(self, message_type):
+    def get_handler(self, message_type) -> HandlerBase:
         return self._handlers[message_type]
 
     def init_additional_handlers(self):
@@ -68,7 +71,7 @@ class SmartAppModel:
         })
 
     @exc_handler(on_error_obj_method_name="on_answer_error")
-    def answer(self, message, user):
+    def answer(self, message, user) -> Optional[List[Command]]:
         user.expire()
         handler = self.get_handler(message.type)
 

--- a/smart_kit/system_answers/nothing_found_action.py
+++ b/smart_kit/system_answers/nothing_found_action.py
@@ -21,5 +21,5 @@ class NothingFoundAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
         commands = super().run(user, text_preprocessing_result, params)
-        commands.extend(self._action.run(user, text_preprocessing_result, params=params))
+        commands.extend(self._action.run(user, text_preprocessing_result, params=params) or [])
         return commands


### PR DESCRIPTION
Проблема: разработчики навыков на фреймворке столкнулись с Exception'ами после доработки https://github.com/salute-developers/smart_app_framework/pull/46, которая исключила поддержку None в качестве ответа Action.run.

Что сделал: решил проблему путём валидация ответа через 'result or []' в местах, уязвимых для None значений.

Теперь следующие утверждения верны:
- Scenario.run возвращает List[Command]
- Action.run во фреймворке всегда возвращает List[Command]
- Action.run аппа возвращает Optional[List[Command]]
- Behaviors.{success, timeout, fail} возвращает List[Command]
- Handler.run во фреймворке возвращает List[Command]
- Handler.run аппа возвращает Optional[List[Command]]