### PR TITLE
DPNLPF-1925:fix message dubling by removing super run in actions

### DIFF
--- a/core/basic_models/actions/basic_actions.py
+++ b/core/basic_models/actions/basic_actions.py
@@ -72,7 +72,7 @@ class DoingNothingAction(CommandAction):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         commands.append(Command(self.command, self.nodes, self.id, request_type=self.request_type,
                                 request_data=self.request_data))
         return commands
@@ -105,7 +105,7 @@ class RequirementAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         if self.requirement.check(text_preprocessing_result, user, params):
             commands.extend(self.internal_item.run(user, text_preprocessing_result, params) or [])
         return commands
@@ -141,7 +141,7 @@ class ChoiceAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         choice_is_made = False
         for item in self.items:
             checked = item.requirement.check(text_preprocessing_result, user, params)
@@ -190,7 +190,7 @@ class ElseAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Optional[Dict[str, Union[str, float, int]]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         if self.requirement.check(text_preprocessing_result, user, params):
             commands.extend(self.item.run(user, text_preprocessing_result, params) or [])
         elif self._else_item:
@@ -215,7 +215,7 @@ class ActionOfActions(Action):
 class CompositeAction(ActionOfActions):
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         for action in self.actions:
             commands.extend(action.run(user, text_preprocessing_result, params) or [])
         return commands
@@ -231,7 +231,7 @@ class NonRepeatingAction(ActionOfActions):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_ids = user.last_action_ids[self._last_action_ids_storage]
         all_indexes = list(range(self._actions_count))
         max_last_ids_count = self._actions_count - 1
@@ -259,7 +259,7 @@ class RandomAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         pos = random.randint(0, len(self._raw_actions) - 1)
         action = self.actions[pos]
         commands.extend(action.run(user, text_preprocessing_result, params=params) or [])

--- a/core/basic_models/actions/basic_actions.py
+++ b/core/basic_models/actions/basic_actions.py
@@ -33,7 +33,7 @@ class Action:
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> Optional[List[Command]]:
-        return []
+        raise NotImplementedError
 
     def on_run_error(self, text_preprocessing_result: BaseTextPreprocessingResult, user: BaseUser):
         log("exc_handler: Action failed to run. Return None. MESSAGE: %(masked_message)s.", user,

--- a/core/basic_models/actions/counter_actions.py
+++ b/core/basic_models/actions/counter_actions.py
@@ -23,7 +23,7 @@ class CounterAction(Action):
 class CounterIncrementAction(CounterAction):
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.counters[self.key].inc(self.value, self.lifetime)
         return commands
 
@@ -31,7 +31,7 @@ class CounterIncrementAction(CounterAction):
 class CounterDecrementAction(CounterAction):
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.counters[self.key].dec(-self.value, self.lifetime)
         return commands
 
@@ -39,7 +39,7 @@ class CounterDecrementAction(CounterAction):
 class CounterClearAction(CounterAction):
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.counters.clear(self.key)
         return commands
 
@@ -59,7 +59,7 @@ class CounterSetAction(CounterAction):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.counters[self.key].set(self.value, self.reset_time, self.time_shift)
         return commands
 
@@ -74,7 +74,7 @@ class CounterCopyAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         value = user.counters[self.src].value
         user.counters[self.dst].set(value, self.reset_time, self.time_shift)
         return commands

--- a/core/basic_models/actions/variable_actions.py
+++ b/core/basic_models/actions/variable_actions.py
@@ -30,7 +30,7 @@ class BaseSetVariableAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         params = user.parametrizer.collect(text_preprocessing_result)
         try:
             # if path is wrong, it may fail with UndefinedError
@@ -78,7 +78,7 @@ class DeleteVariableAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.variables.delete(self.key)
         return commands
 
@@ -91,7 +91,7 @@ class ClearVariablesAction(Action):
 
     def run(self, user: BaseUser, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.variables.clear()
         return commands
 

--- a/scenarios/actions/action.py
+++ b/scenarios/actions/action.py
@@ -36,7 +36,7 @@ class ClearFormAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.forms.remove_item(self.form)
         return commands
 
@@ -53,7 +53,7 @@ class ClearInnerFormAction(ClearFormAction):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         form = user.forms[self.form]
         if form:
             form.forms.remove_item(self.inner_form)
@@ -73,7 +73,7 @@ class RemoveFormFieldAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         form = user.forms[self.form]
         form.fields.remove_item(self.field)
         return commands
@@ -92,7 +92,7 @@ class RemoveCompositeFormFieldAction(RemoveFormFieldAction):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         form = user.forms[self.form]
         inner_form = form.forms[self.inner_form]
         inner_form.fields.remove_item(self.field)
@@ -108,7 +108,7 @@ class BreakScenarioAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         scenario_id = self.scenario_id if self.scenario_id is not None else user.last_scenarios.last_scenario_name
         user.scenario_models[scenario_id].set_break()
         return commands
@@ -127,7 +127,7 @@ class SaveBehaviorAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         scenario_id = None
         if self.check_scenario:
             scenario_id = user.last_scenarios.last_scenario_name
@@ -166,10 +166,10 @@ class BasicSelfServiceActionWithState(StringAction):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         if self._check(user):
             commands.extend(self._run(user, text_preprocessing_result, params))
-            return commands
+        return commands
 
 
 class FillFieldAction(Action):
@@ -196,7 +196,7 @@ class FillFieldAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         params = user.parametrizer.collect(text_preprocessing_result)
         data = self._get_data(params)
         self._fill(user, data)
@@ -228,7 +228,7 @@ class RunScenarioAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         if params is None:
             params = user.parametrizer.collect(text_preprocessing_result)
         else:
@@ -243,7 +243,7 @@ class RunScenarioAction(Action):
 class RunLastScenarioAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_scenario_id = user.last_scenarios.last_scenario_name
         scenario = user.descriptions["scenarios"].get(last_scenario_id)
         if scenario:
@@ -279,7 +279,7 @@ class ChoiceScenarioAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         choice_is_made = False
 
         for scenario, requirement in zip(self._scenarios, self.requirement_items):
@@ -304,7 +304,7 @@ def clear_scenario(user, scenario_id):
 class ClearCurrentScenarioAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_scenario_id = user.last_scenarios.last_scenario_name
         if last_scenario_id:
             clear_scenario(user, last_scenario_id)
@@ -314,7 +314,7 @@ class ClearCurrentScenarioAction(Action):
 class ClearAllScenariosAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         user.last_scenarios.clear_all()
         return commands
 
@@ -330,7 +330,7 @@ class ClearScenarioByIdAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         if self.scenario_id:
             clear_scenario(user, self.scenario_id)
         return commands
@@ -342,7 +342,7 @@ class ClearCurrentScenarioFormAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_scenario_id = user.last_scenarios.last_scenario_name
         if last_scenario_id:
             user.forms.clear_form(last_scenario_id)
@@ -356,7 +356,7 @@ class ResetCurrentNodeAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_scenario_id = user.last_scenarios.last_scenario_name
         if last_scenario_id:
             user.scenario_models[last_scenario_id].current_node = self.node_id
@@ -379,7 +379,7 @@ class AddHistoryEventAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         last_scenario_id = user.last_scenarios.last_scenario_name
         scenario = user.descriptions["scenarios"].get(last_scenario_id)
         if scenario:
@@ -406,7 +406,7 @@ class AddHistoryEventAction(Action):
 class EmptyAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         log("%(class_name)s.run: action do nothing.",
             params={log_const.KEY_NAME: "empty_action", "class_name": self.__class__.__name__}, user=user)
         return commands
@@ -415,7 +415,7 @@ class EmptyAction(Action):
 class RunScenarioByProjectNameAction(Action):
     def run(self, user: User, text_preprocessing_result: TextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         scenario_id = user.message.project_name
         scenario = user.descriptions["scenarios"].get(scenario_id)
         if scenario:
@@ -431,7 +431,7 @@ class RunScenarioByProjectNameAction(Action):
 class ProcessBehaviorAction(Action):
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         callback_id = user.message.callback_id
 
         log(f"%(class_name)s.run: got callback_id %({log_const.BEHAVIOR_CALLBACK_ID_VALUE})s.",

--- a/smart_kit/message/smartapp_to_message.py
+++ b/smart_kit/message/smartapp_to_message.py
@@ -5,6 +5,7 @@ from copy import copy
 
 from core.utils.masking_message import masking
 from core.message.msg_validator import MessageValidator
+from smart_kit.request.kafka_request import SmartKitKafkaRequest
 from smart_kit.utils import SmartAppToMessage_pb2
 
 
@@ -12,7 +13,7 @@ class SmartAppToMessage:
     ROOT_NODES_KEY = "root_nodes"
     PAYLOAD = "payload"
 
-    def __init__(self, command, message, request, forward_fields=None, masking_fields=None,
+    def __init__(self, command, message, request: SmartKitKafkaRequest, forward_fields=None, masking_fields=None,
                  validators: Iterable[MessageValidator] = ()):
         root_nodes = command.payload.pop(self.ROOT_NODES_KEY, None)
         self.command = command

--- a/smart_kit/system_answers/nothing_found_action.py
+++ b/smart_kit/system_answers/nothing_found_action.py
@@ -20,6 +20,6 @@ class NothingFoundAction(Action):
 
     def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         commands.extend(self._action.run(user, text_preprocessing_result, params=params) or [])
         return commands

--- a/smart_kit/template/app/basic_entities/actions.py-tpl
+++ b/smart_kit/template/app/basic_entities/actions.py-tpl
@@ -19,6 +19,6 @@ class CustomAction(Action):
 
     def run(self, user: User, text_preprocessing_result: TextPreprocessingResult,
             params: Optional[Dict[str, Union[str, float, int]]] = None) -> List[Command]:
-        commands = super().run(user, text_preprocessing_result, params)
+        commands = []
         # тело действия
         return commands

--- a/tests/core_tests/basic_scenario_models_test/action_test/test_action.py
+++ b/tests/core_tests/basic_scenario_models_test/action_test/test_action.py
@@ -109,8 +109,7 @@ class ActionTest(unittest.TestCase):
     def test_base(self):
         items = {"nodes": "test"}
         action = Action(items)
-        result = action.run(None, None)
-        self.assertEqual(result, [])
+        self.assertRaises(NotImplementedError, action.run, None, None)
 
     def test_external(self):
         items = {"action": "test_action_key"}

--- a/tests/scenarios_tests/actions_test/test_action.py
+++ b/tests/scenarios_tests/actions_test/test_action.py
@@ -190,7 +190,7 @@ class SelfServiceActionWithStateTest(unittest.TestCase):
         action = SelfServiceActionWithState(data)
         result = action.run(self.user, None)
         behavior.add.assert_not_called()
-        self.assertIsNone(result)
+        self.assertEqual(result, [])
 
     def test_action_3(self):
         data = {"behavior": "test", "command_action": {"command": "cmd_id", "nodes": {}, "request_data": {}}}


### PR DESCRIPTION
Проблема: вызывается два запроса вместо одного из-за "наследования" логики метода run() у акшнов. 

Пример проблемы: при использовании self_service_with_state сообщение отправляется два раза из-за того, что тут используется action BaseSelfServiceWithState, где в run сначала выполняется super().run(), который и так генерирует команду отправки сообщения и метод self._run, который генерирует точно такую же команду.  В результате сообщение отправляется два раза. 

Решение: убрал "наследование" логики через super().run() в акшнах, где она не нужна, чтобы избежать этого и других возможных инцидентов.