### PR TITLE
DPNLPF-1885: fix monitoring access

### DIFF
--- a/core/db_adapter/ceph/ceph_adapter.py
+++ b/core/db_adapter/ceph/ceph_adapter.py
@@ -35,7 +35,7 @@ class CephAdapter(DBAdapter):
                 params={log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE},
                 level="ERROR",
                 exc_info=True)
-            monitoring.monitoring.got_counter("ceph_connection_exception")
+            monitoring.got_counter("ceph_connection_exception")
             raise
 
     @property

--- a/core/db_adapter/db_adapter.py
+++ b/core/db_adapter/db_adapter.py
@@ -144,5 +144,5 @@ class AsyncDBAdapter(DBAdapter):
             result = await self._async_run(action, *args, _try_count=_try_count, **kwargs)
             counter_name = self._get_counter_name()
             if counter_name:
-                monitoring.monitoring.got_counter(f"{counter_name}_exception")
+                monitoring.got_counter(f"{counter_name}_exception")
         return result

--- a/core/db_adapter/ignite_adapter.py
+++ b/core/db_adapter/ignite_adapter.py
@@ -54,7 +54,7 @@ class IgniteAdapter(AsyncDBAdapter):
                 params={log_const.KEY_NAME: log_const.HANDLED_EXCEPTION_VALUE},
                 level="ERROR",
                 exc_info=True)
-            monitoring.monitoring.got_counter("ignite_connection_exception")
+            monitoring.got_counter("ignite_connection_exception")
             raise
 
     async def _save(self, id, data):
@@ -74,7 +74,7 @@ class IgniteAdapter(AsyncDBAdapter):
         if self._client is None:
             log('Attempt to recreate ignite instance', level="WARNING")
             await self.connect()
-            monitoring.monitoring.got_counter("ignite_reconnection")
+            monitoring.got_counter("ignite_reconnection")
         return self._cache
 
     @property

--- a/core/mq/kafka/async_kafka_publisher.py
+++ b/core/mq/kafka/async_kafka_publisher.py
@@ -30,7 +30,7 @@ class AsyncKafkaPublisher(KafkaPublisher):
             }
             log("KafkaProducer: Local producer queue is full (%(queue_amount)s messages awaiting delivery):"
                 " try again\n", params=params, level="ERROR")
-            monitoring.monitoring.got_counter("kafka_producer_exception")
+            monitoring.got_counter("kafka_producer_exception")
 
     def send_to_topic(self, value, key=None, topic=None, headers=None):
         try:
@@ -52,7 +52,7 @@ class AsyncKafkaPublisher(KafkaPublisher):
             }
             log("KafkaProducer: Local producer queue is full (%(queue_amount)s messages awaiting delivery):"
                 " try again\n", params=params, level="ERROR")
-            monitoring.monitoring.got_counter("kafka_producer_exception")
+            monitoring.got_counter("kafka_producer_exception")
 
     def _poll_for_callbacks(self):
         poll_timeout = self._config.get("poll_timeout", 1)

--- a/core/mq/kafka/kafka_consumer.py
+++ b/core/mq/kafka/kafka_consumer.py
@@ -107,7 +107,7 @@ class KafkaConsumer(BaseKafkaConsumer):
             log_const.KEY_NAME: log_const.EXCEPTION_VALUE
         }
         log("KafkaConsumer: Error: %(error)s", params=params, level="WARNING")
-        monitoring.monitoring.got_counter("kafka_consumer_exception")
+        monitoring.got_counter("kafka_consumer_exception")
 
     # noinspection PyMethodMayBeStatic
     def _process_message(self, msg: KafkaMessage):
@@ -116,7 +116,7 @@ class KafkaConsumer(BaseKafkaConsumer):
             if err.code() == KafkaError._PARTITION_EOF:
                 return None
             else:
-                monitoring.monitoring.got_counter("kafka_consumer_exception")
+                monitoring.got_counter("kafka_consumer_exception")
                 params = {
                     "code": err.code(),
                     "pid": os.getpid(),

--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -41,7 +41,7 @@ class KafkaPublisher(BaseKafkaPublisher):
             }
             log("KafkaProducer: Local producer queue is full (%(queue_amount)s messages awaiting delivery):"
                        " try again\n", params=params, level="ERROR")
-            monitoring.monitoring.got_counter("kafka_producer_exception")
+            monitoring.got_counter("kafka_producer_exception")
         self._poll()
 
     def send_to_topic(self, value, key=None, topic=None, headers=None):
@@ -64,7 +64,7 @@ class KafkaPublisher(BaseKafkaPublisher):
             }
             log("KafkaProducer: Local producer queue is full (%(queue_amount)s messages awaiting delivery):"
                        " try again\n", params=params, level="ERROR")
-            monitoring.monitoring.got_counter("kafka_producer_exception")
+            monitoring.got_counter("kafka_producer_exception")
         self._poll()
 
     def _poll(self):
@@ -81,7 +81,7 @@ class KafkaPublisher(BaseKafkaPublisher):
             log_const.KEY_NAME: log_const.EXCEPTION_VALUE
         }
         log("KafkaProducer: Error: %(error)s", params=params, level="ERROR")
-        monitoring.monitoring.got_counter("kafka_producer_exception")
+        monitoring.got_counter("kafka_producer_exception")
 
     def _delivery_callback(self, err, msg):
         if err:
@@ -101,7 +101,7 @@ class KafkaPublisher(BaseKafkaPublisher):
                                       log_const.KEY_NAME: log_const.EXCEPTION_VALUE},
                               level="ERROR",
                               exc_info=True)
-            monitoring.monitoring.got_counter("kafka_producer_exception")
+            monitoring.got_counter("kafka_producer_exception")
 
     def close(self):
         self._producer.flush(self._config["flush_timeout"])

--- a/core/request/rest_request.py
+++ b/core/request/rest_request.py
@@ -37,7 +37,7 @@ class RestRequest(BaseRequest):
             return method(data)
 
     def on_timeout_error(self, *args, **kwarg):
-        monitoring.monitoring.got_counter("core_rest_run_timeout")
+        monitoring.got_counter("core_rest_run_timeout")
 
     def _requests_get(self, params):
         return requests.get(self.url, params=params, **self.rest_args).text

--- a/core/unified_template/unified_template.py
+++ b/core/unified_template/unified_template.py
@@ -49,7 +49,7 @@ class UnifiedTemplate:
                         "params_dict_str": str(params_dict)},
                 level="ERROR",
                 exc_info=True)
-            monitoring.monitoring.got_counter("core_jinja_template_error")
+            monitoring.got_counter("core_jinja_template_error")
             raise
         return result
 

--- a/core/utils/rerunable.py
+++ b/core/utils/rerunable.py
@@ -44,7 +44,7 @@ class Rerunable():
             result = self._run(action, *args, _try_count=_try_count, **kwargs)
             counter_name = self._get_counter_name()
             if counter_name:
-                monitoring.monitoring.got_counter(f"{counter_name}_exception")
+                monitoring.got_counter(f"{counter_name}_exception")
         return result
 
     def _get_counter_name(self):


### PR DESCRIPTION
Проблема: апп кидает рейсы, когда происходит обращение к monitoring.monitoring.поле (инстансу from core.monitoring.monitoring import monitoring), так как такого поля больше нет у инстанса, это легаси.
```
monitoring.monitoring.pod_event(self.app_name, POD_UP)
  File "/Users/19134925/Documents/Documents/Code/Sber/framework_testing/smart_app_framework/core/monitoring/monitoring.py", line 314, in __getattr__
    return getattr(self.instance, item)
AttributeError: 'Monitoring' object has no attribute 'monitoring'
```

Решение: заменить обращение monitoring.monitoring.поле на monitoring.поле.