### PR TITLE
DPNLPF-1991: Fix log Publishing time

### DIFF
--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -342,7 +342,7 @@ class MainLoop(BaseMainLoop):
                         for answer in answers:
                             with StatsTimer() as publish_timer:
                                 self._send_request(user, answer, mq_message)
-                            stats += "Publishing time: {} msecs".format(publish_timer.msecs)
+                            stats += "Publishing time: {} msecs\n".format(publish_timer.msecs)
                             log(stats, user=user)
             else:
                 try:


### PR DESCRIPTION
Проблема: склеиваются логи "Publishing time: {} msecs" из-за отсутствия \n в конце.

Решение: добавить \n в конце проблемного лога.