### PR TITLE
Feature/DPNLPF-1943: skip old message

### DIFF
--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -357,8 +357,8 @@ class MainLoop(BaseMainLoop):
     def _is_message_timeout_to_skip(self, message: SmartAppFromMessage, waiting_message_time: int):
         # Returns True if timeout is found
         waiting_message_timeout = self.template_settings.get("waiting_message_timeout", {})
-        warning_delay = waiting_message_timeout.get('warning', 200)
-        skip_delay = waiting_message_timeout.get('skip', 8000)
+        warning_delay = waiting_message_timeout.get("warning", 200)
+        skip_delay = waiting_message_timeout.get("skip", 8000)
         log_level = None
         make_break = False
 
@@ -374,8 +374,8 @@ class MainLoop(BaseMainLoop):
             monitoring.counter_mq_long_waiting(self.app_name)
 
         if log_level is not None:
-            log(f"Out of time message %(waiting_message_time)s msecs, "
-                f"mid: %(mid)s ",
+            log("Out of time message %(waiting_message_time)s msecs, "
+                "mid: %(mid)s ",
                 params={
                     log_const.KEY_NAME: "waiting_message_timeout",
                     "waiting_message_time": waiting_message_time,

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -27,8 +27,6 @@ from core.mq.kafka.kafka_consumer import KafkaConsumer
 from core.utils.memstats import get_top_malloc
 from core.utils.pickle_copy import pickle_deepcopy
 from core.utils.stats_timer import StatsTimer
-from core.utils.utils import current_time_ms
-from scenarios.user.user_model import User
 from smart_kit.compatibility.commands import combine_commands
 from smart_kit.message.get_to_message import get_to_message
 from smart_kit.message.smartapp_to_message import SmartAppToMessage

--- a/smart_kit/start_points/main_loop_kafka.py
+++ b/smart_kit/start_points/main_loop_kafka.py
@@ -358,7 +358,7 @@ class MainLoop(BaseMainLoop):
         # Returns True if timeout is found
         waiting_message_timeout = self.template_settings.get("waiting_message_timeout", {})
         warning_delay = waiting_message_timeout.get('warning', 200)
-        skip_delay = waiting_message_timeout.get('skip', 6000)
+        skip_delay = waiting_message_timeout.get('skip', 8000)
         log_level = None
         make_break = False
 


### PR DESCRIPTION
Добавлен функционала пропуска сообщений из кафки, которые пролежали больше таймаута по app_request. Дефолтная длительность таймаута - таймаут для app_request на b2c (8 сек).

Доработку протестировал на локально поднятом навыке. Навык пропускает обработку + error log, если сообщению 8 сек+, или пишет warning, но обрабатывает, если сообщению 0.2 сек+.