### PR TITLE
DPNLPF-2013: remove dubbling of monitoring.counter_incoming in handlers

### DIFF
--- a/smart_kit/handlers/handle_respond.py
+++ b/smart_kit/handlers/handle_respond.py
@@ -10,7 +10,6 @@ from scenarios.user.user_model import User
 
 from smart_kit.handlers.handler_base import HandlerBase
 from smart_kit.names.action_params_names import TO_MESSAGE_NAME, SEND_TIMESTAMP
-from core.monitoring.monitoring import monitoring
 
 
 class HandlerRespond(HandlerBase):
@@ -46,8 +45,6 @@ class HandlerRespond(HandlerBase):
             log("HandlerRespond with action %(action_name)s started respond on %(to_message_name)s", user, params)
         else:
             log("HandlerRespond with action %(action_name)s started without callback", user, params)
-
-        monitoring.counter_incoming(self.app_name, user.message.message_name, self.__class__.__name__, user)
 
         text_preprocessing_result = TextPreprocessingResult.from_payload(payload)
 

--- a/smart_kit/handlers/handle_server_action.py
+++ b/smart_kit/handlers/handle_server_action.py
@@ -10,7 +10,6 @@ from core.utils.pickle_copy import pickle_deepcopy
 from scenarios.user.user_model import User
 
 from smart_kit.handlers.handler_base import HandlerBase
-from core.monitoring.monitoring import monitoring
 
 
 class HandlerServerAction(HandlerBase):
@@ -33,10 +32,6 @@ class HandlerServerAction(HandlerBase):
                   "server_action_params": str(action_params),
                   "server_action_id": self.get_action_name(payload, user)}
         log("HandlerServerAction %(server_action_id)s started", user, params)
-
-        app_info = user.message.app_info
-        monitoring.counter_incoming(self.app_name, user.message.message_name, self.__class__.__name__,
-                                    user, app_info=app_info)
 
         action_id = self.get_action_name(payload, user)
         action = user.descriptions["external_actions"][action_id]

--- a/smart_kit/handlers/handler_timeout.py
+++ b/smart_kit/handlers/handler_timeout.py
@@ -15,7 +15,7 @@ from core.monitoring.monitoring import monitoring
 class HandlerTimeout(HandlerBase):
 
     async def run(self, payload: Dict[str, Any], user: User) -> List[Command]:
-        commands = await super().run(payload, user)
+        commands = []
         callback_id = user.message.callback_id
         if user.behaviors.has_callback(callback_id):
             params = {log_const.KEY_NAME: "handling_timeout"}


### PR DESCRIPTION
Проблема: дублируются метрики по количеству входящих сообщений в HandlerRespond, HandlerServerAction и HandlerTimeout. Из-за этого навыки не могут пройти НТ.

Решение: удалён повтор отправки метрик в Handlers.