### PR TITLE
PNLP-7328: map reply_topic_key to kafka_replyTopic before kafka request

### DIFF
--- a/core/basic_models/actions/client_profile_actions.py
+++ b/core/basic_models/actions/client_profile_actions.py
@@ -2,6 +2,7 @@ from typing import Dict, Any, Optional, Union, List
 
 from core.basic_models.actions.command import Command
 from core.basic_models.actions.string_actions import StringAction
+from core.configs.config_constants import REPLY_TOPIC_KEY
 from core.configs.global_constants import KAFKA, KAFKA_REPLY_TOPIC
 from core.text_preprocessing.base import BaseTextPreprocessingResult
 from core.utils.pickle_copy import pickle_deepcopy
@@ -62,11 +63,14 @@ class GiveMeMemoryAction(StringAction):
         })
         settings_kafka_key = config["template_settings"].get("client_profile_kafka_key")
         self.kafka_key: str = self.kafka_key or settings_kafka_key or self.DEFAULT_KAFKA_KEY
-        self.request_data = {
-            "topic_key": "client_info",
-            "kafka_key": self.kafka_key,
-            KAFKA_REPLY_TOPIC: config["template_settings"]["consumer_topic"]
-        }
+        if self.request_data is None:
+            self.request_data = dict()
+        if "topic_key" not in self.request_data:
+            self.request_data["topic_key"] = "client_info"
+        if "kafka_key" not in self.request_data:
+            self.request_data["kafka_key"] = self.kafka_key
+        if REPLY_TOPIC_KEY not in self.request_data and KAFKA_REPLY_TOPIC not in self.request_data:
+            self.request_data[KAFKA_REPLY_TOPIC] = config["template_settings"]["consumer_topic"]
 
     async def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
                   params: Optional[Dict[str, Union[str, float, int]]] = None) -> Optional[List[Command]]:
@@ -143,6 +147,7 @@ class RememberThisAction(StringAction):
 
     def __init__(self, items: Dict[str, Any], id: Optional[str] = None):
         super().__init__(items, id)
+        config = settings.Settings()
         self.command = REMEMBER_THIS
         self.request_type = KAFKA
         self.kafka_key: Optional[str] = items.get("kafka_key")
@@ -151,6 +156,16 @@ class RememberThisAction(StringAction):
                 "protocolVersion": items.get("protocolVersion", 3)
             }
         })
+        if self.request_data is None:
+            self.request_data = dict()
+        if "topic_key" not in self.request_data:
+            self.request_data["topic_key"] = "client_info_remember"
+        if "kafka_key" not in self.request_data:
+            settings_kafka_key: Optional[str] = config["template_settings"].get("client_profile_kafka_key")
+            kafka_key: str = self.kafka_key or settings_kafka_key or self.DEFAULT_KAFKA_KEY
+            self.request_data["kafka_key"] = kafka_key
+        if REPLY_TOPIC_KEY not in self.request_data and KAFKA_REPLY_TOPIC not in self.request_data:
+            self.request_data[KAFKA_REPLY_TOPIC] = config["template_settings"]["consumer_topic"]
 
     async def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
                   params: Optional[Dict[str, Union[str, float, int]]] = None) -> Optional[List[Command]]:
@@ -159,13 +174,6 @@ class RememberThisAction(StringAction):
                 "projectId": user.settings["template_settings"]["project_id"]
             }
         })
-        settings_kafka_key: Optional[str] = user.settings["template_settings"].get("client_profile_kafka_key")
-        kafka_key: str = self.kafka_key or settings_kafka_key or self.DEFAULT_KAFKA_KEY
-        self.request_data = {
-            "topic_key": "client_info_remember",
-            "kafka_key": kafka_key,
-            KAFKA_REPLY_TOPIC: user.settings["template_settings"]["consumer_topic"]
-        }
 
         commands = await super().run(user, text_preprocessing_result, params)
         return commands

--- a/core/basic_models/actions/client_profile_actions.py
+++ b/core/basic_models/actions/client_profile_actions.py
@@ -147,7 +147,6 @@ class RememberThisAction(StringAction):
 
     def __init__(self, items: Dict[str, Any], id: Optional[str] = None):
         super().__init__(items, id)
-        config = settings.Settings()
         self.command = REMEMBER_THIS
         self.request_type = KAFKA
         self.kafka_key: Optional[str] = items.get("kafka_key")
@@ -156,16 +155,6 @@ class RememberThisAction(StringAction):
                 "protocolVersion": items.get("protocolVersion", 3)
             }
         })
-        if self.request_data is None:
-            self.request_data = dict()
-        if "topic_key" not in self.request_data:
-            self.request_data["topic_key"] = "client_info_remember"
-        if "kafka_key" not in self.request_data:
-            settings_kafka_key: Optional[str] = config["template_settings"].get("client_profile_kafka_key")
-            kafka_key: str = self.kafka_key or settings_kafka_key or self.DEFAULT_KAFKA_KEY
-            self.request_data["kafka_key"] = kafka_key
-        if REPLY_TOPIC_KEY not in self.request_data and KAFKA_REPLY_TOPIC not in self.request_data:
-            self.request_data[KAFKA_REPLY_TOPIC] = config["template_settings"]["consumer_topic"]
 
     async def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
                   params: Optional[Dict[str, Union[str, float, int]]] = None) -> Optional[List[Command]]:
@@ -174,6 +163,16 @@ class RememberThisAction(StringAction):
                 "projectId": user.settings["template_settings"]["project_id"]
             }
         })
+        if self.request_data is None:
+            self.request_data = dict()
+        if "topic_key" not in self.request_data:
+            self.request_data["topic_key"] = "client_info_remember"
+        if "kafka_key" not in self.request_data:
+            settings_kafka_key: Optional[str] = user.settings["template_settings"].get("client_profile_kafka_key")
+            kafka_key: str = self.kafka_key or settings_kafka_key or self.DEFAULT_KAFKA_KEY
+            self.request_data["kafka_key"] = kafka_key
+        if REPLY_TOPIC_KEY not in self.request_data and KAFKA_REPLY_TOPIC not in self.request_data:
+            self.request_data[KAFKA_REPLY_TOPIC] = user.settings["template_settings"]["consumer_topic"]
 
         commands = await super().run(user, text_preprocessing_result, params)
         return commands

--- a/core/basic_models/actions/client_profile_actions.py
+++ b/core/basic_models/actions/client_profile_actions.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional, Union, List
 
 from core.basic_models.actions.command import Command
 from core.basic_models.actions.string_actions import StringAction
-from core.configs.global_constants import KAFKA
+from core.configs.global_constants import KAFKA, KAFKA_REPLY_TOPIC
 from core.text_preprocessing.base import BaseTextPreprocessingResult
 from core.utils.pickle_copy import pickle_deepcopy
 from scenarios.user.user_model import User
@@ -65,8 +65,7 @@ class GiveMeMemoryAction(StringAction):
         self.request_data = {
             "topic_key": "client_info",
             "kafka_key": self.kafka_key,
-            "kafka_replyTopic":
-                config["template_settings"]["consumer_topic"]
+            KAFKA_REPLY_TOPIC: config["template_settings"]["consumer_topic"]
         }
 
     async def run(self, user: User, text_preprocessing_result: BaseTextPreprocessingResult,
@@ -165,8 +164,7 @@ class RememberThisAction(StringAction):
         self.request_data = {
             "topic_key": "client_info_remember",
             "kafka_key": kafka_key,
-            "kafka_replyTopic":
-                user.settings["template_settings"]["consumer_topic"]
+            KAFKA_REPLY_TOPIC: user.settings["template_settings"]["consumer_topic"]
         }
 
         commands = await super().run(user, text_preprocessing_result, params)

--- a/core/configs/config_constants.py
+++ b/core/configs/config_constants.py
@@ -1,0 +1,2 @@
+REPLY_TOPIC = "reply_topic"
+REPLY_TOPIC_KEY = "reply_topic_key"

--- a/core/logging/logger_utils.py
+++ b/core/logging/logger_utils.py
@@ -10,6 +10,7 @@ import core.basic_models.classifiers.classifiers_constants as cls_const
 import core.logging.logger_constants as log_const
 import scenarios.logging.logger_constants as scenarios_log_const
 from core.basic_models.classifiers.basic_classifiers import Classifier
+from core.configs.global_constants import KAFKA_REPLY_TOPIC
 from core.utils.masking_message import masking
 from core.utils.stats_timer import StatsTimer
 
@@ -22,7 +23,7 @@ HEADERS = "headers"
 
 
 class LoggerMessageCreator:
-    LOGGER_HEADERS = ["kafka_replyTopic", "app_callback_id"]
+    LOGGER_HEADERS = [KAFKA_REPLY_TOPIC, "app_callback_id"]
     ART_NAMES = [
         "channel", "type", "device_channel", "device_channel_version", "device_platform", "group",
         "device_platform_version", "device_platform_client_type", "csa_profile_id", "test_deploy"

--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import time
-from typing import Union, Optional, Dict
+from typing import Union, Optional, Dict, List, Tuple, Any
 
 from confluent_kafka import Producer
 
@@ -30,15 +30,15 @@ class KafkaPublisher(BaseKafkaPublisher):
             conf["logger"] = debug_logger
         self._producer = Producer(**conf)
 
-    def _map_reply_topic_key(self, headers: Optional[Dict]):
-        if headers and REPLY_TOPIC_KEY in headers:
-            reply_topic_key = headers[REPLY_TOPIC_KEY]
-            reply_topics = self._config[REPLY_TOPIC]
-            mapped_reply_topic = reply_topics[reply_topic_key]
-            headers.pop(REPLY_TOPIC_KEY)
-            headers[KAFKA_REPLY_TOPIC] = mapped_reply_topic.encode()
+    def _map_reply_topic_key(self, headers: Optional[List[Tuple[Any, Any]]]):
+        if headers:
+            for i, (key, value) in headers:
+                reply_topics = self._config[REPLY_TOPIC]
+                if key == REPLY_TOPIC_KEY:
+                    mapped_reply_topic = reply_topics[value]
+                    headers[i] = (KAFKA_REPLY_TOPIC, mapped_reply_topic.encode())
 
-    def send(self, value: Union[str, bytes], key=None, topic_key=None, headers: Optional[Dict] = None):
+    def send(self, value: Union[str, bytes], key=None, topic_key=None, headers: Optional[List[Tuple[Any, Any]]] = None):
         try:
             topic = self._config["topic"]
             if topic_key is not None:
@@ -58,7 +58,7 @@ class KafkaPublisher(BaseKafkaPublisher):
             monitoring.got_counter("kafka_producer_exception")
         self._poll()
 
-    def send_to_topic(self, value, key=None, topic=None, headers=None):
+    def send_to_topic(self, value, key=None, topic=None, headers: Optional[List[Tuple[Any, Any]]] = None):
         try:
             if topic is None:
                 params = {

--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -67,6 +67,12 @@ class KafkaPublisher(BaseKafkaPublisher):
             producer_params = dict()
             if key is not None:
                 producer_params["key"] = key
+            if headers and REPLY_TOPIC_KEY in headers:
+                reply_topic_key = headers[REPLY_TOPIC_KEY]
+                reply_topics = self._config[REPLY_TOPIC]
+                mapped_reply_topic = reply_topics[reply_topic_key]
+                headers.pop(REPLY_TOPIC_KEY)
+                headers[KAFKA_REPLY_TOPIC] = mapped_reply_topic
             self._producer.produce(topic=topic, value=value, headers=headers or [], **producer_params)
         except BufferError:
             params = {

--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -36,7 +36,7 @@ class KafkaPublisher(BaseKafkaPublisher):
             reply_topics = self._config[REPLY_TOPIC]
             mapped_reply_topic = reply_topics[reply_topic_key]
             headers.pop(REPLY_TOPIC_KEY)
-            headers[KAFKA_REPLY_TOPIC] = mapped_reply_topic
+            headers[KAFKA_REPLY_TOPIC] = mapped_reply_topic.encode()
 
     def send(self, value: Union[str, bytes], key=None, topic_key=None, headers: Optional[Dict] = None):
         try:

--- a/core/mq/kafka/kafka_publisher.py
+++ b/core/mq/kafka/kafka_publisher.py
@@ -7,6 +7,8 @@ from typing import Union
 from confluent_kafka import Producer
 
 import core.logging.logger_constants as log_const
+from core.configs.config_constants import REPLY_TOPIC_KEY, REPLY_TOPIC
+from core.configs.global_constants import KAFKA_REPLY_TOPIC
 from core.logging.logger_utils import log
 from core.monitoring.monitoring import monitoring
 from core.mq.kafka.base_kafka_publisher import BaseKafkaPublisher
@@ -36,6 +38,12 @@ class KafkaPublisher(BaseKafkaPublisher):
             producer_params = dict()
             if key is not None:
                 producer_params["key"] = key
+            if headers and REPLY_TOPIC_KEY in headers:
+                reply_topic_key = headers[REPLY_TOPIC_KEY]
+                reply_topics = self._config[REPLY_TOPIC]
+                mapped_reply_topic = reply_topics[reply_topic_key]
+                headers.pop(REPLY_TOPIC_KEY)
+                headers[KAFKA_REPLY_TOPIC] = mapped_reply_topic
             self._producer.produce(topic=topic, value=value, headers=headers or [], **producer_params)
         except BufferError:
             params = {

--- a/core/request/kafka_request.py
+++ b/core/request/kafka_request.py
@@ -13,7 +13,7 @@ class KafkaRequest(BaseRequest):
     TOPIC = "topic"
 
     def __init__(self, items, id=None):
-        super(KafkaRequest, self).__init__(items)
+        super().__init__(items)
         items = items or {}
         self.topic_key = items.get(self.TOPIC_KEY)
         self.kafka_key = items.get(self.KAFKA_KEY)

--- a/smart_kit/request/kafka_request.py
+++ b/smart_kit/request/kafka_request.py
@@ -1,27 +1,36 @@
 from core.configs.global_constants import CALLBACK_ID_HEADER, KAFKA_REPLY_TOPIC
 from core.request.kafka_request import KafkaRequest
+from core.configs.config_constants import REPLY_TOPIC_KEY, REPLY_TOPIC
+from smart_kit.configs.settings import Settings
 
 
 class SmartKitKafkaRequest(KafkaRequest):
     KAFKA_REPLY_TOPIC = KAFKA_REPLY_TOPIC
     KAFKA_EXTRA_HEADERS = "kafka_extraHeaders"
+    REPLY_TOPIC_KEY = REPLY_TOPIC_KEY
 
     def __init__(self, items, id=None):
-        super(SmartKitKafkaRequest, self).__init__(items)
+        super().__init__(items)
         items = items or {}
         self._callback_id = items.get(self._callback_id_header_name)
         self._kafka_replyTopic = items.get(self.KAFKA_REPLY_TOPIC)
         self._kafka_extraHeaders = items.get(self.KAFKA_EXTRA_HEADERS) or {}
+        # _reply_topic_key has priority over _kafka_replyTopic
+        self._reply_topic_key = items.get(self.REPLY_TOPIC_KEY)
 
     @property
     def _callback_id_header_name(self):
         return CALLBACK_ID_HEADER
 
     def _get_new_headers(self, source_mq_message):
-        headers_dict = dict(super(SmartKitKafkaRequest, self)._get_new_headers(source_mq_message))
+        headers_dict = dict(super()._get_new_headers(source_mq_message))
         if self._callback_id:
             headers_dict[self._callback_id_header_name] = str(self._callback_id).encode()
-        if self._kafka_replyTopic:
+        if self._reply_topic_key:
+            reply_topics = Settings()["template_settings"][REPLY_TOPIC]
+            mapped_reply_topic = reply_topics[self._reply_topic_key]
+            headers_dict[self.KAFKA_REPLY_TOPIC] = str(mapped_reply_topic).encode()
+        elif self._kafka_replyTopic:
             headers_dict[self.KAFKA_REPLY_TOPIC] = str(self._kafka_replyTopic).encode()
         if self._kafka_extraHeaders:
             for k, v in self._kafka_extraHeaders.items():


### PR DESCRIPTION
Новый функционал: задание header'а `kafka_replyTopic` через указание `reply_topic_key` в `Command.request_data` (для акшнов, отнаследованных от `CommandAction`, этому соответствует итем `request_data`) в соответствие с маппингом из конфига перед отправкой запроса. Маппинг задаётся в конфиге так: в конфиге `template_config.yml` в поле `reply_topic` указывается набор ключ-значений в формате `reply_topic_key: kafka_replyTopic`. `reply_topic_key` имеет приоритет над `kafka_replyTopic`, то есть в случае наличия обоих полей выберется `reply_topic_key`.