### PR TITLE
bug/incorrect-aiohttp-app-init:

### DIFF
--- a/smart_kit/start_points/main_loop_async_http.py
+++ b/smart_kit/start_points/main_loop_async_http.py
@@ -18,8 +18,8 @@ from core.monitoring.monitoring import monitoring
 
 class AIOHttpMainLoop(BaseHttpMainLoop):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.app = aiohttp.web.Application()
+        super().__init__(*args, **kwargs)
         self.app.add_routes([aiohttp.web.route('*', '/health', self.get_health_check)])
         self.app.add_routes([aiohttp.web.route('*', '/{tail:.*}', self.iterate)])
 


### PR DESCRIPTION
При базовом классе AIOHttpMainLoop происходила ошибка при старте. Сервер не мог стартовать и падал в методе AIOHttpMainLoop.get_db на строчке self.app.on_cleanup.append(self.close_db), тк объекта аппа еще не существует. Правка примитивна