### PR TITLE
PNLP-8011: fix ignite reconnect

### DIFF
--- a/core/db_adapter/ignite_adapter.py
+++ b/core/db_adapter/ignite_adapter.py
@@ -1,11 +1,12 @@
 # coding: utf-8
 import random
 from concurrent.futures._base import CancelledError
+from typing import Optional
 
 import pyignite
 from pyignite import AioClient
 from pyignite.aio_cache import AioCache
-from pyignite.exceptions import ReconnectError, SocketError
+from pyignite.exceptions import ReconnectError, SocketError, CacheError
 
 import core.logging.logger_constants as log_const
 from core.db_adapter import error
@@ -15,7 +16,7 @@ from core.monitoring.monitoring import monitoring
 
 
 class IgniteAdapter(AsyncDBAdapter):
-    _client: AioClient
+    _client: Optional[AioClient]
     _cache = AioCache
 
     def __init__(self, config):
@@ -80,9 +81,9 @@ class IgniteAdapter(AsyncDBAdapter):
     @property
     def _handled_exception(self):
         # TypeError is raised during reconnection if all nodes are exhausted
-        return OSError, SocketError, ReconnectError, CancelledError
+        return OSError, SocketError, ReconnectError, CancelledError, CacheError
 
-    async def _on_prepare(self):
+    def _on_prepare(self):
         self._client = None
 
     async def _get_counter_name(self):


### PR DESCRIPTION
Были несостыкованы питонячие интерфейсы. `DBAdapter` при ошибке подключения внутри `self._async_run` вызывал `self._on_prepare`, который был частью логики восстановления соединения. Но вызов происходил синхронно, а в `IgniteAdapter` интерфейс метода асинхронный, поэтому логика не отрабатывала. Я исправил интерфейс метода в `IgniteAdapter`.