### PR TITLE
DPNLPF-2339: update ubuntu version from 20.04 to 24.04

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-version: ['ubuntu-20.04']
+        os-version: ['ubuntu-24.04']
         python-version: ['3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os-version }}


### PR DESCRIPTION
update ubuntu for GitHub actions runner since previous version (20.04) is deprecated